### PR TITLE
Cheap patch to ignore header rows on recovery

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -60,7 +60,9 @@ trait CassandraRecovery { this: CassandraJournal =>
         val row = iter.next()
         val marker = row.getString("marker")
         val snr = row.getLong("sequence_nr")
-        if (marker == "A") {
+        if (marker == "H") {
+          // ignore header
+        } else if (marker == "A") {
           val m = persistentFromByteBuffer(row.getBytes("message"))
           // there may be duplicates returned by iter
           // (on scan boundaries within a partition)


### PR DESCRIPTION
Not sure if this is the most effective fix for issue https://github.com/krasserm/akka-persistence-cassandra/issues/8, but it seems to work for my use case.
