### PR TITLE
Cassandra datacenter aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ To connect to the Cassandra hosts with credentials, add the following lines:
 - `cassandra-journal.authentication.username`. The username to use to login to Cassandra hosts. No authentication is set as default.
 - `cassandra-journal.authentication.password`. The password corresponding to username. No authentication is set as default.
 
+To limit the Cassandra hosts this plugin connects with to a specific datacenter, use the following setting:
+
+- `cassandra-journal.local-datacenter`.  The id for the local datacenter of the Cassandra hosts that this module should connect to.  By default, this property is not set resulting in Datastax's standard round robin policy being used.
+
 ### Caveats
 
 - Detailed tests under failure conditions are still missing.
@@ -93,6 +97,10 @@ To connect to the Cassandra hosts with credentials, add the following lines:
 
 - `cassandra-snapshot-store.authentication.username`. The username to use to login to Cassandra hosts. No authentication is set as default.
 - `cassandra-snapshot-store.authentication.password`. The password corresponding to username. No authentication is set as default.
+
+To limit the Cassandra hosts this plugin connects with to a specific datacenter, use the following setting:
+
+- `cassandra-snapshot-store.local-datacenter`.  The id for the local datacenter of the Cassandra hosts that this module should connect to.  By default, this property is not set resulting in Datastax's standard round robin policy being used.
 
 
 

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -14,6 +14,7 @@ import akka.serialization.SerializationExtension
 
 import com.datastax.driver.core._
 import com.datastax.driver.core.utils.Bytes
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
 
 class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with CassandraStatements {
   val config = context.system.settings.config.getConfig("cassandra-journal")
@@ -27,12 +28,19 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
 
   val serialization = SerializationExtension(context.system)
 
-  val clusterBuilder = Cluster.builder.addContactPoints(config.getStringList("contact-points").asScala: _*)
+  private val clusterBuilder = Cluster.builder.addContactPoints(config.getStringList("contact-points").asScala: _*)
   if(config.hasPath("authentication")) {
     clusterBuilder.withCredentials(
       config.getString("authentication.username"),
       config.getString("authentication.password"))
   }
+
+  if(config.hasPath("local-datacenter")) {
+    clusterBuilder.withLoadBalancingPolicy(
+      new DCAwareRoundRobinPolicy(config.getString("local-datacenter"))
+    )
+  }
+
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -17,6 +17,7 @@ import akka.serialization.SerializationExtension
 
 import com.datastax.driver.core._
 import com.datastax.driver.core.utils.Bytes
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
 
 /**
  * Optimized and fully async version of [[akka.persistence.snapshot.SnapshotStore]].
@@ -78,6 +79,13 @@ class CassandraSnapshotStore extends CassandraSnapshotStoreEndpoint with Cassand
       config.getString("authentication.username"),
       config.getString("authentication.password"))
   }
+
+  if(config.hasPath("local-datacenter")) {
+    clusterBuilder.withLoadBalancingPolicy(
+      new DCAwareRoundRobinPolicy(config.getString("local-datacenter"))
+    )
+  }
+
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 


### PR DESCRIPTION
We add an optional local datacenter property here in order to support using a specific Cassandra cluster within a multi-datacenter environment.

This pull request assumes the one we have for authentication support gets merged in.  
