### PR TITLE
Bump cassandra-driver-core to 2.0.5.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ fork in Test := true
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.0.3",
+  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.0.5",
   "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.5",
   "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.5"   % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",


### PR DESCRIPTION
A couple of severe bugs were closed in 2.0.4 (see [changelog](https://datastax-oss.atlassian.net/browse/JAVA?selectedTab=com.atlassian.jira.jira-projects-plugin:changelog-panel)).  My team update to 2.0.5 and thought the pull request can save you a couple of keystrokes.
