### PR TITLE
Cassandra 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To include the Cassandra plugins into your `sbt` project, add the following line
 
     libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.3.3"
 
-This version of `akka-persistence-cassandra` depends on Akka 2.3.4 and is cross-built against Scala 2.10.4 and 2.11.0. It is compatible with Cassandra 2.0.3 or higher. 
+This version of `akka-persistence-cassandra` depends on Akka 2.3.4 and is cross-built against Scala 2.10.4 and 2.11.0. It is compatible with Cassandra protocol version 1.2. 
 
 Journal plugin
 --------------
@@ -36,9 +36,16 @@ This will run the journal with its default settings. The default settings can be
 
 - `cassandra-journal.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`.
 - `cassandra-journal.port`. Port to use to connect to the Cassandra host. Default value is `9042`.
-- `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka`.
-- `cassandra-journal.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `messages`.
-- `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
+- `cassandra-journal-configure-keyspace`. Boolean value to signify if a keyspace needs to be configured.Default value is `true`. Possible values are `true` or `false`.
+- `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. Default keyspace value is `akka`.
+- `cassandra-journal-keyspace-strategyClass`. Signifies which strategy class to be used while creating the keyspace. Default value is `SimpleStrategy`. Possible values are `SimpleStrategy` and  `NetworkTopologyStrategy`.
+- `cassandra-journal-keyspace-strategyClass-DC1`. First DataCenter Name if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `DC1`.
+- `cassandra-journal-keyspace-strategyClass-DC1-replication-factor`. First Datacenter replicator factor to be used if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `1`.
+- `cassandra-journal-keyspace-strategyClass-DC2`. Second DataCenter Name if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `DC2`.
+- `cassandra-journal-keyspace-strategyClass-DC2-replication-factor`. Second Datacenter replicator factor to be used if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `1`.
+- `cassandra-journal-configure-table`. Boolean value to signify if a table needs to be configured.Default value is `true`. Possible values are `true` or `false`.
+- `cassandra-journal.table`. Name of the table to be used by the plugin.Default value is `messages`.
+- `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created with default strategy class `SimpleStrategy`. Default value is `1`.
 - `cassandra-journal.max-partition-size`. Maximum number of entries (messages, confirmations and deletion markers) per partition. Default value is 5000000. **Do not change this setting after table creation** (not checked yet).
 - `cassandra-journal.max-result-size`. Maximum number of entries returned per query. Queries are executed recursively, if needed, to achieve recovery goals. Default value is 50001.
 - `cassandra-journal.write-consistency`. Write consistency level. Default value is `QUORUM`.
@@ -81,10 +88,17 @@ This will run the snapshot store with its default settings. The default settings
 
 - `cassandra-snapshot-store.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`.
 - `cassandra-snapshot-store.port`. Port to use to connect to the Cassandra host. Default value is `9042`.
-- `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka_snapshot`.
-- `cassandra-snapshot-store.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `snapshots`.
-- `cassandra-snapshot-store.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
-- `cassandra-snapshot-store.max-metadata-result-size`. Maximum number of snapshot metadata to load per recursion (when trying to find a snapshot that matches specified selection criteria). Default value is `10`. Only increase this value when selection criteria frequently select snapshots that are much older than the most recent snapshot i.e. if there are much more than 10 snapshots between the most recent one and selected one. This setting is only for increasing load efficiency of snapshots.
+- `cassandra-snapshot-configure-keyspace`. Boolean value to signify if a keyspace needs to be configured.Default value is `true`. Possible values are `true` or `false`.
+- `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin.Default value is `akka_snapshot`.
+- `cassandra-snapshot-keyspace-strategyClass`. Signifies which strategy class to be used while creating the keyspace. Default value is `SimpleStrategy`. Possible values are `SimpleStrategy` and `NetworkTopologyStrategy`.
+- `cassandra-snapshot-keyspace-strategyClass-DC1`. First DataCenter Name if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `DC1`.
+- `cassandra-snapshot-keyspace-strategyClass-DC1-replication-factor`.First Datacenter replicator factor to be used if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `1`.
+- `cassandra-snapshot-keyspace-strategyClass-DC2`. Second DataCenter Name if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `DC2`.
+- `cassandra-snapshot-keyspace-strategyClass-DC2-replication-factor`.Second Datacenter replicator factor to be used if keyspace strategy class is `NetworkTopologyStrategy`.Default value is `1`.
+- `cassandra-snapshot-configure-table`. Boolean value to signify if a table needs to be configured.Default value is `true`.Possible values are `true` or `false`.
+- `cassandra-snapshot-store.table`. Name of the table to be used by the plugin.Default value is `snapshots`.
+- `cassandra-snapshot-store.replication-factor`. Replication factor to use when a keyspace is created with default strategy class `SimpleStrategy`.Default value is `1`.
+- `cassandra-snapshot-store.max-metadata-result-size`.Maximum number of snapshot metadata to load per recursion (when trying to find a snapshot that matches specified selection criteria). Default value is `10`. Only increase this value when selection criteria frequently select snapshots that are much older than the most recent snapshot i.e. if there are much more than 10 snapshots between the most recent one and selected one. This setting is only for increasing load efficiency of snapshots.
 - `cassandra-snapshot-store.write-consistency`. Write consistency level. Default value is `ONE`.
 - `cassandra-snapshot-store.read-consistency`. Read consistency level. Default value is `ONE`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,10 +13,12 @@ fork in Test := true
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.0.3",
+  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.0.1",
   "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.5",
   "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.5"   % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",
-  "org.cassandraunit"       % "cassandra-unit"                    % "2.0.2.1" % "test"
+  "org.cassandraunit"       % "cassandra-unit"                    % "1.2.0.1" % "test" exclude("com.datastax.cassandra","cassandra-driver-core") exclude("org.apache.cassandra","cassandra-all"),
+  "org.apache.cassandra" % "cassandra-all"  % "1.2.13"
 )
+
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,9 +9,30 @@ cassandra-journal {
   # Port of contact points in the cluster
   port = 9042
 
+  # Keyspace to be configured or not
+  configure-keyspace = true
+  
   # Name of the keyspace to be created/used by the journal
   keyspace = "akka"
+  
+  # Keyspace strategy class
+  keyspace-strategyClass = "SimpleStrategy"
+  
+  # Keyspace DC1 name
+  keyspace-strategyClass-DC1 = "DC1"
+  
+  # Keyspace DC1 replication factor
+  keyspace-strategyClass-DC1-replication-factor = 1
+  
+  # Keyspace DC2 name
+  keyspace-strategyClass-DC2 = "DC2"
+  
+  # Keyspace DC2 replication factor
+  keyspace-strategyClass-DC2-replication-factor = 1
 
+  # Table to be configured or not
+  configure-table = true
+  
   # Name of the table to be created/used by the journal
   table = "messages"
 
@@ -49,8 +70,30 @@ cassandra-snapshot-store {
   # Port of contact points in the cluster
   port = 9042
 
+  # Keyspace to be configured or not
+  configure-keyspace = true
+  
   # Name of the keyspace to be created/used by the snapshot store
   keyspace = "akka_snapshot"
+  
+   # Keyspace strategy class
+  keyspace-strategyClass = "SimpleStrategy"
+  
+  # Keyspace DC1 name
+  keyspace-strategyClass-DC1 = "DC1"
+  
+  # Keyspace DC1 replication factor
+  keyspace-strategyClass-DC1-replication-factor = 1
+  
+  # Keyspace DC2 name
+  keyspace-strategyClass-DC2 = "DC2"
+  
+  # Keyspace DC2 replication factor
+  keyspace-strategyClass-DC2-replication-factor = 1
+
+  # Table to be configured or not
+  configure-table = true
+  
 
   # Name of the table to be created/used by the snapshot store
   table = "snapshots"

--- a/src/main/scala/akka/persistence/cassandra/CassandraPlugin.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPlugin.scala
@@ -1,0 +1,97 @@
+package akka.persistence.cassandra
+
+import com.typesafe.config.Config
+import com.datastax.driver.core.Session
+import akka.event.LoggingAdapter
+import com.datastax.driver.core.exceptions.AlreadyExistsException
+
+trait CassandraPlugin {
+  def logger: LoggingAdapter
+  def config: CassandraPluginConfig
+  
+  def createKeyspaceWithNetworkTopologyStrategy(DC1: String, DC1ReplicationFactor: Int, DC2: String, DC2ReplicatiobFactor: Int) = s"""
+      CREATE KEYSPACE ${config.keyspace}
+      WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '${DC1}' : ${DC1ReplicationFactor}, '${DC2}' : ${DC2ReplicatiobFactor} }
+  """
+  def createKeyspaceWithSimpleStrategy(replicationFactor: Int) = s"""
+      CREATE KEYSPACE ${config.keyspace}
+      WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : ${replicationFactor}}
+  """
+
+  def createJournalTable = s"""
+      CREATE TABLE ${tableName} (
+        processor_id text,
+        partition_nr bigint,
+        sequence_nr bigint,
+        marker text,
+        message blob,
+        PRIMARY KEY ((processor_id, partition_nr), sequence_nr, marker))
+        WITH COMPACT STORAGE
+    """
+  
+  def createSnapshotTable = s"""
+      CREATE TABLE ${tableName} (
+        processor_id text,
+        sequence_nr bigint,
+        timestamp bigint,
+        snapshot blob,
+        PRIMARY KEY (processor_id, sequence_nr))
+        WITH CLUSTERING ORDER BY (sequence_nr DESC)
+    """
+  
+  def createKeyspace(session:Session) {
+    if(config.configureKeyspace){
+      if(config.keyspaceStrategyClass == "NetworkTopologyStrategy"){
+        try {
+          session.execute(createKeyspaceWithNetworkTopologyStrategy(config.keyspaceStrategyClassDC1Name,config.keyspaceStrategyClassDC1RepFactor,config.keyspaceStrategyClassDC2Name,config.keyspaceStrategyClassDC2RepFactor))
+          }catch {
+            case ae: AlreadyExistsException => logger.info("Keyspace not created as it already exists : " + ae);
+            case e: Exception => {
+              logger.error("Unknown error while creating keyspace: " + e);
+              throw e;
+             }
+          }
+        }
+      else {
+        try {
+          session.execute(createKeyspaceWithSimpleStrategy(config.replicationFactor))
+          }catch {
+            case ae: AlreadyExistsException => logger.info("Keyspace not created as it already exists : " + ae);
+            case e: Exception => {
+              logger.error("Unknown error while creating keyspace: " + e);
+              throw e;
+              }
+            }
+          }
+      }
+  }
+  
+  def createJournalTable(session:Session){
+  if(config.configureTable){
+    try {
+      session.execute(createJournalTable)
+      }catch {
+        case ae: AlreadyExistsException => logger.info("Table not created as it already exists: " + ae);
+        case e: Exception => {
+          logger.error("Unknown error while creating table: " + e);
+          throw e;
+          }
+        }
+      }
+  }
+  
+  def createSnapshotTable(session:Session){
+  if(config.configureTable){
+    try {
+      session.execute(createSnapshotTable)
+      }catch {
+          case ae: AlreadyExistsException => logger.info("Table not created as it already exists: " + ae);
+          case e: Exception => {
+           logger.error("Unknown error while creating table: " + e);
+           throw e;
+          }
+        }
+      }
+  }
+  private def tableName = s"${config.keyspace}.${config.table}"
+}

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -9,6 +9,13 @@ import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
 class CassandraPluginConfig(config: Config) {
   val keyspace: String = config.getString("keyspace")
   val table: String = config.getString("table")
+  val configureKeyspace: Boolean = config.getBoolean("configure-keyspace")
+  val configureTable: Boolean = config.getBoolean("configure-table")
+  val keyspaceStrategyClass: String = config.getString("keyspace-strategyClass")
+  val keyspaceStrategyClassDC1Name: String = config.getString("keyspace-strategyClass-DC1")
+  val keyspaceStrategyClassDC1RepFactor: Int = config.getInt("keyspace-strategyClass-DC1-replication-factor")
+  val keyspaceStrategyClassDC2Name: String = config.getString("keyspace-strategyClass-DC2")
+  val keyspaceStrategyClassDC2RepFactor: Int = config.getInt("keyspace-strategyClass-DC2-replication-factor")
 
   val replicationFactor: Int = config.getInt("replication-factor")
   val readConsistency: ConsistencyLevel = ConsistencyLevel.valueOf(config.getString("read-consistency"))

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -3,49 +3,6 @@ package akka.persistence.cassandra.journal
 trait CassandraStatements {
   def config: CassandraJournalConfig
 
-  def createKeyspace(replicationFactor: Int) = s"""
-      CREATE KEYSPACE IF NOT EXISTS ${config.keyspace}
-      WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : ${replicationFactor} }
-    """
-
-  def createTable = s"""
-      CREATE TABLE IF NOT EXISTS ${tableName} (
-        processor_id text,
-        partition_nr bigint,
-        sequence_nr bigint,
-        marker text,
-        message blob,
-        PRIMARY KEY ((processor_id, partition_nr), sequence_nr, marker))
-        WITH COMPACT STORAGE
-    """
-
-  def writeHeader = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, 0, 'H', 0x00)
-    """
-
-  def writeMessage = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, ?, 'A', ?)
-    """
-
-  def confirmMessage = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, ?, ?, 0x00)
-    """
-
-  def deleteMessageLogical = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, ?, 'B', 0x00)
-    """
-
-  def deleteMessagePermanent = s"""
-      DELETE FROM ${tableName} WHERE
-        processor_id = ? AND
-        partition_nr = ? AND
-        sequence_nr = ?
-    """
-
   def selectHeader = s"""
       SELECT * FROM ${tableName} WHERE
         processor_id = ? AND

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -3,21 +3,6 @@ package akka.persistence.cassandra.snapshot
 trait CassandraStatements {
   def config: CassandraSnapshotStoreConfig
 
-  def createKeyspace(replicationFactor: Int) = s"""
-      CREATE KEYSPACE IF NOT EXISTS ${config.keyspace}
-      WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : ${replicationFactor} }
-    """
-
-  def createTable = s"""
-      CREATE TABLE IF NOT EXISTS ${tableName} (
-        processor_id text,
-        sequence_nr bigint,
-        timestamp bigint,
-        snapshot blob,
-        PRIMARY KEY (processor_id, sequence_nr))
-        WITH CLUSTERING ORDER BY (sequence_nr DESC)
-    """
-
   def writeSnapshot = s"""
       INSERT INTO ${tableName} (processor_id, sequence_nr, timestamp, snapshot)
       VALUES (?, ?, ?, ?)


### PR DESCRIPTION
Hi Martin,

I have made the changes to make this plugin usable with lower version of cassandra 1.2/1.2.x, changes on a high level are captured below, also the changes passes all testcases. Request you to review and let me know your comments.
1. Datastax cassandra driver downgraded from 2.0.3 to 2.0.1(support cassandra version 1.2)
2. Cassandra-unit downgraded
3. Support added to create Keyspace with NeyworkTopologyStrategy also
4. BatchStatements replaces with CQL query batch wrapped in prepared statements
5. Parameterized Statements replaces with Prepared and Bound statements
6. Updated Readme.md

Thanks
Ratika
