### PR TITLE
cassandra config should handle host:port pairs as contact points

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To activate the journal plugin, add the following line to your Akka `application
 
 This will run the journal with its default settings. The default settings can be changed with the following configuration keys:
 
-- `cassandra-journal.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`.
-- `cassandra-journal.port`. Port to use to connect to the Cassandra host. Default value is `9042`.
+- `cassandra-journal.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`. Host:Port pairs are also supported. In that case the port parameter will be ignored.
+- `cassandra-journal.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
 - `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka`.
 - `cassandra-journal.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `messages`.
 - `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
@@ -79,8 +79,8 @@ To activate the snapshot-store plugin, add the following line to your Akka `appl
 
 This will run the snapshot store with its default settings. The default settings can be changed with the following configuration keys:
 
-- `cassandra-snapshot-store.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`.
-- `cassandra-snapshot-store.port`. Port to use to connect to the Cassandra host. Default value is `9042`.
+- `cassandra-snapshot-store.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`. Host:Port pairs are also supported. In that case the port parameter will be ignored.
+- `cassandra-snapshot-store.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
 - `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka_snapshot`.
 - `cassandra-snapshot-store.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `snapshots`.
 - `cassandra-snapshot-store.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -1,22 +1,27 @@
 package akka.persistence.cassandra
 
+import java.net.InetSocketAddress
+
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
+import com.datastax.driver.core.{Cluster, ConsistencyLevel}
+import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 
-import com.typesafe.config.Config
-import com.datastax.driver.core.{ConsistencyLevel, Cluster}
-import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
-
 class CassandraPluginConfig(config: Config) {
+
+  import akka.persistence.cassandra.CassandraPluginConfig._
+
   val keyspace: String = config.getString("keyspace")
   val table: String = config.getString("table")
 
   val replicationFactor: Int = config.getInt("replication-factor")
   val readConsistency: ConsistencyLevel = ConsistencyLevel.valueOf(config.getString("read-consistency"))
   val writeConsistency: ConsistencyLevel = ConsistencyLevel.valueOf(config.getString("write-consistency"))
+  val port: Int = config.getInt("port")
+  val contactPoints = getContactPoints(config.getStringList("contact-points").asScala, port)
 
   val clusterBuilder: Cluster.Builder = Cluster.builder
-    .addContactPoints(config.getStringList("contact-points").asScala: _*)
-    .withPort(config.getInt("port"))
+    .addContactPointsWithPorts(contactPoints.asJava)
 
   if (config.hasPath("authentication")) {
     clusterBuilder.withCredentials(
@@ -28,5 +33,24 @@ class CassandraPluginConfig(config: Config) {
     clusterBuilder.withLoadBalancingPolicy(
       new DCAwareRoundRobinPolicy(config.getString("local-datacenter"))
     )
+  }
+}
+
+object CassandraPluginConfig {
+
+  /**
+   * Builds list of InetSocketAddress out of host:port pairs or host entries + given port parameter.
+   */
+  def getContactPoints(contactPoints: Seq[String], port: Int): Seq[InetSocketAddress] = {
+    contactPoints match {
+      case null | Nil => throw new IllegalArgumentException("A contact point list cannot be empty.")
+      case hosts => hosts map {
+        ipWithPort => ipWithPort.split(":") match {
+          case Array(host, port) => new InetSocketAddress(host, port.toInt)
+          case Array(host) => new InetSocketAddress(host, port)
+          case msg => throw new IllegalArgumentException(s"A contact point should have the form [host:port] or [host] but was: $msg.")
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -1,0 +1,65 @@
+package akka.persistence.cassandra
+
+import java.net.InetSocketAddress
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{MustMatchers, Matchers, WordSpec}
+
+/**
+ *
+ */
+class CassandraPluginConfigTest extends WordSpec with MustMatchers {
+  lazy val configWithHostPortPair = ConfigFactory.parseString(
+    """
+      |
+      |keyspace = test-keyspace
+      |table = test-table
+      |replication-factor = 1
+      |read-consistency = QUORUM
+      |write-consistency = QUORUM
+      |contact-points = ["127.0.0.1:19142", "127.0.0.1:29142"]
+      |port = 9142
+    """.stripMargin)
+
+  lazy val configWithHosts = ConfigFactory.parseString(
+    """
+      |
+      |keyspace = test-keyspace
+      |table = test-table
+      |replication-factor = 1
+      |read-consistency = QUORUM
+      |write-consistency = QUORUM
+      |contact-points = ["127.0.0.1", "127.0.0.2"]
+      |port = 9142
+    """.stripMargin)
+
+  "A CassandraPluginConfig" should {
+    "parse config with host:port values as contact points" in {
+      val config = new CassandraPluginConfig(configWithHostPortPair)
+      config.contactPoints must be(
+        List(
+          new InetSocketAddress("127.0.0.1", 19142),
+          new InetSocketAddress("127.0.0.1", 29142)
+        )
+      )
+
+    }
+    "parse config with a list of contact points without port" in {
+      val config = new CassandraPluginConfig(configWithHosts)
+      config.contactPoints must be(
+        List(
+          new InetSocketAddress("127.0.0.1", 9142),
+          new InetSocketAddress("127.0.0.2", 9142)
+        )
+      )
+    }
+    "throw an exception when contact point list is empty" in {
+      intercept[IllegalArgumentException] {
+        CassandraPluginConfig.getContactPoints(List.empty, 0)
+      }
+      intercept[IllegalArgumentException] {
+        CassandraPluginConfig.getContactPoints(null, 0)
+      }
+    }
+  }
+}


### PR DESCRIPTION
see #34 
