### PR TITLE
cleanup + library updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,20 +4,33 @@ name := "akka-persistence-cassandra"
 
 version := "0.4-SNAPSHOT"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.4"
 
-crossScalaVersions := Seq("2.10.4", "2.11.0")
+crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 fork in Test := true
 
 javaOptions in Test += "-Xmx2500M"
 
+scalacOptions ++= Seq(
+  "-encoding", "UTF-8",
+  "-feature",
+  "-unchecked",
+  "-deprecation",
+  //"-Xfatal-warnings",
+  "-Xlint",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Xfuture"
+)
+
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.1",
-  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.6",
-  "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.6"   % "test",
+  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.8",
+  "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.8"   % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",
   "org.cassandraunit"       % "cassandra-unit"                    % "2.0.2.2" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.7

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -45,7 +45,7 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
 
   def asyncWriteConfirmations(confirmations: Seq[PersistentConfirmation]): Future[Unit] = executeBatch { batch =>
     confirmations.foreach { c =>
-      batch.add((preparedConfirmMessage.bind(c.processorId, partitionNr(c.sequenceNr): JLong, c.sequenceNr: JLong, confirmMarker(c.channelId))))
+      batch.add((preparedConfirmMessage.bind(c.persistenceId, partitionNr(c.sequenceNr): JLong, c.sequenceNr: JLong, confirmMarker(c.channelId))))
     }
   }
 

--- a/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/src/main/scala/akka/persistence/cassandra/package.scala
@@ -2,11 +2,11 @@ package akka.persistence
 
 import java.util.concurrent.Executor
 
-import scala.concurrent._
-import scala.util.Try
-
 import com.google.common.util.concurrent.ListenableFuture
 
+import scala.concurrent._
+import scala.language.implicitConversions
+import scala.util.Try
 package object cassandra {
   implicit def listenableFutureToFuture[A](lf: ListenableFuture[A])(implicit executionContext: ExecutionContext): Future[A] = {
     val promise = Promise[A]

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -27,10 +27,12 @@ object CassandraIntegrationSpec {
     """.stripMargin)
 
   case class Delete(snr: Long, permanent: Boolean)
+
   case class DeleteTo(snr: Long, permanent: Boolean)
 
   class ProcessorA(val persistenceId: String) extends PersistentActor {
     def receiveRecover: Receive = handle
+
     def receiveCommand: Receive = {
       case Delete(sequenceNr, permanent) =>
         deleteMessage(sequenceNr, permanent)
@@ -39,6 +41,7 @@ object CassandraIntegrationSpec {
       case payload: String =>
         persist(payload)(handle)
     }
+
     def handle: Receive = {
       case payload: String =>
         sender ! payload
@@ -88,8 +91,10 @@ object CassandraIntegrationSpec {
     }
 
     override def autoUpdate: Boolean = false
+
     override def autoUpdateReplayMax: Long = 0
   }
+
 }
 
 import CassandraIntegrationSpec._
@@ -110,7 +115,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
   def awaitRangeDeletion(probe: TestProbe): Unit =
     probe.expectMsgType[JournalProtocol.DeleteMessagesTo]
 
-  def testIndividualDelete(processorId: String, permanent: Boolean) {
+  def testIndividualDelete(processorId: String, permanent: Boolean): Unit = {
     val deleteProbe = TestProbe()
     subscribeToBatchDeletion(deleteProbe)
 
@@ -144,7 +149,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
     }
   }
 
-  def testRangeDelete(processorId: String, permanent: Boolean) {
+  def testRangeDelete(processorId: String, permanent: Boolean): Unit = {
     val deleteProbe = TestProbe()
     subscribeToRangeDeletion(deleteProbe)
 

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
@@ -8,6 +8,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 object CassandraLoadSpec {
   val config = ConfigFactory.parseString(
@@ -27,8 +28,8 @@ object CassandraLoadSpec {
     var startTime: Long = 0L
     var stopTime: Long = 0L
 
-    var startSequenceNr = 0L;
-    var stopSequenceNr = 0L;
+    var startSequenceNr = 0L
+    var stopSequenceNr = 0L
 
     def startMeasure(): Unit = {
       startSequenceNr = lastSequenceNr


### PR DESCRIPTION
I  know that was not demanded but I thought a refresh doesn't hurt: 

* upgraded to scala 2.11.4 
* upgraded to sbt 0.13.7 
* upgraded to akka 2.3.8 
* removed deprecation warnings where possible 
* added compiler flags to support clean code

Don't want to stress you during vacation ;) 