### PR TITLE
Issue #45 - keyspace autocreation fails when cassandra user doesn't have...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ This will run the journal with its default settings. The default settings can be
 
 - `cassandra-journal.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`. Host:Port pairs are also supported. In that case the port parameter will be ignored.
 - `cassandra-journal.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
-- `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka`.
+- `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. Default value is `akka`.
+- `cassandra-journal.keyspace-autocreate`. Boolean parameter indicating whether the keyspace should be automatically created if it doesn't exist. Default value is `true`.
 - `cassandra-journal.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `messages`.
 - `cassandra-journal.replication-strategy`. Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
 - `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
@@ -83,7 +84,8 @@ This will run the snapshot store with its default settings. The default settings
 
 - `cassandra-snapshot-store.contact-points`. A comma-separated list of contact points in a Cassandra cluster. Default value is `[127.0.0.1]`. Host:Port pairs are also supported. In that case the port parameter will be ignored.
 - `cassandra-snapshot-store.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
-- `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin. If the keyspace doesn't exist it is automatically created. Default value is `akka_snapshot`.
+- `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin. Default value is `akka_snapshot`.
+- `cassandra-snapshot-store.keyspace-autocreate`. Boolean parameter indicating whether the keyspace should be automatically created if it doesn't exist. Default value is `true`.
 - `cassandra-snapshot-store.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `snapshots`.
 - `cassandra-snapshot-store.replication-strategy`. Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
 - `cassandra-snapshot-store.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,6 +12,9 @@ cassandra-journal {
   # Name of the keyspace to be created/used by the journal
   keyspace = "akka"
 
+  # Parameter indicating whether the journal keyspace should be auto created
+  keyspace-autocreate = true
+
   # Name of the table to be created/used by the journal
   table = "messages"
 
@@ -61,6 +64,9 @@ cassandra-snapshot-store {
 
   # Name of the keyspace to be created/used by the snapshot store
   keyspace = "akka_snapshot"
+
+  # Parameter indicating whether the snapshot keyspace should be auto created
+  keyspace-autocreate = true
 
   # Name of the table to be created/used by the snapshot store
   table = "snapshots"

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -14,6 +14,7 @@ class CassandraPluginConfig(config: Config) {
   val keyspace: String = config.getString("keyspace")
   val table: String = config.getString("table")
 
+  val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
 
   val replicationStrategy: String = getReplicationStrategy(
     config.getString("replication-strategy"),

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -24,7 +24,7 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 
-  session.execute(createKeyspace)
+  if (config.keyspaceAutoCreate) session.execute(createKeyspace)
   session.execute(createTable)
 
   val preparedWriteHeader = session.prepare(writeHeader)

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -71,7 +71,7 @@ class CassandraSnapshotStore extends CassandraSnapshotStoreEndpoint with Cassand
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 
-  session.execute(createKeyspace)
+  if (config.keyspaceAutoCreate) session.execute(createKeyspace)
   session.execute(createTable)
 
   val preparedWriteSnapshot = session.prepare(writeSnapshot).setConsistencyLevel(writeConsistency)

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.{MustMatchers, WordSpec}
 class CassandraPluginConfigTest extends WordSpec with MustMatchers {
   lazy val defaultConfig = ConfigFactory.parseString(
     """
+      |keyspace-autocreate = true
       |keyspace = test-keyspace
       |table = test-table
       |replication-strategy = "SimpleStrategy"
@@ -87,6 +88,13 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
       intercept[IllegalArgumentException] {
         CassandraPluginConfig.getReplicationStrategy("NetworkTopologyStrategy", 0, Seq("dc1"))
       }
+    }
+
+    "parse keyspace-autocreate parameter" in {
+      val configWithFalseKeyspaceAutocreate = ConfigFactory.parseString( """keyspace-autocreate = false""").withFallback(defaultConfig)
+
+      val config = new CassandraPluginConfig(configWithFalseKeyspaceAutocreate)
+      config.keyspaceAutoCreate must be(false)
     }
   }
 }


### PR DESCRIPTION
... appropriate permissions. The new boolean parameter is called `cassandra-journal.keyspace-autocreate` because `cassandra-journal.keyspace.autocreate` would breake the `val keyspace: String = config.getString("keyspace")` line.