### PR TITLE
Added retry mechanism in case that schema creation fails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This will run the journal with its default settings. The default settings can be
 - `cassandra-journal.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
 - `cassandra-journal.keyspace`. Name of the keyspace to be used by the plugin. Default value is `akka`.
 - `cassandra-journal.keyspace-autocreate`. Boolean parameter indicating whether the keyspace should be automatically created if it doesn't exist. Default value is `true`.
+- `cassandra-journal.keyspace-autocreate-retries`. Int parameter which defines a number of retries before giving up on automatic schema creation. Default value is `1`.
 - `cassandra-journal.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `messages`.
 - `cassandra-journal.replication-strategy`. Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
 - `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
@@ -86,6 +87,7 @@ This will run the snapshot store with its default settings. The default settings
 - `cassandra-snapshot-store.port`. Port to use to connect to the Cassandra host. Default value is `9042`. Will be ignored if the contact point list is defined by host:port pairs.
 - `cassandra-snapshot-store.keyspace`. Name of the keyspace to be used by the plugin. Default value is `akka_snapshot`.
 - `cassandra-snapshot-store.keyspace-autocreate`. Boolean parameter indicating whether the keyspace should be automatically created if it doesn't exist. Default value is `true`.
+- `cassandra-snapshot-store.keyspace-autocreate-retries`. Int parameter which defines a number of retries before giving up on automatic schema creation. Default value is `1`.
 - `cassandra-snapshot-store.table`. Name of the table to be used by the plugin. If the table doesn't exist it is automatically created. Default value is `snapshots`.
 - `cassandra-snapshot-store.replication-strategy`. Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
 - `cassandra-snapshot-store.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,9 @@ cassandra-journal {
   # Parameter indicating whether the journal keyspace should be auto created
   keyspace-autocreate = true
 
+  # In case that schema creation failed you can define a number of retries before giving up.
+  keyspace-autocreate-retries = 1
+
   # Name of the table to be created/used by the journal
   table = "messages"
 
@@ -67,6 +70,9 @@ cassandra-snapshot-store {
 
   # Parameter indicating whether the snapshot keyspace should be auto created
   keyspace-autocreate = true
+
+  # In case that schema creation failed you can define a number of retries before giving up.
+  keyspace-autocreate-retries = 1
 
   # Name of the table to be created/used by the snapshot store
   table = "snapshots"

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -15,6 +15,7 @@ class CassandraPluginConfig(config: Config) {
   val table: String = config.getString("table")
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
+  val keyspaceAutoCreateRetries: Int = config.getInt("keyspace-autocreate-retries")
 
   val replicationStrategy: String = getReplicationStrategy(
     config.getString("replication-strategy"),

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -24,7 +24,11 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 
-  if (config.keyspaceAutoCreate) session.execute(createKeyspace)
+  if (config.keyspaceAutoCreate) {
+    retry(config.keyspaceAutoCreateRetries) {
+      session.execute(createKeyspace)
+    }
+  }
   session.execute(createTable)
 
   val preparedWriteHeader = session.prepare(writeHeader)

--- a/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/src/main/scala/akka/persistence/cassandra/package.scala
@@ -6,11 +6,19 @@ import com.google.common.util.concurrent.ListenableFuture
 
 import scala.concurrent._
 import scala.language.implicitConversions
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 package object cassandra {
   implicit def listenableFutureToFuture[A](lf: ListenableFuture[A])(implicit executionContext: ExecutionContext): Future[A] = {
     val promise = Promise[A]
     lf.addListener(new Runnable { def run() = promise.complete(Try(lf.get())) }, executionContext.asInstanceOf[Executor])
     promise.future
+  }
+  @annotation.tailrec
+  def retry[T](n: Int)(fn: => T): T = {
+    Try { fn } match {
+      case Success(x) => x
+      case _ if n > 1 => retry(n - 1)(fn)
+      case Failure(e) => throw e
+    }
   }
 }

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -71,7 +71,11 @@ class CassandraSnapshotStore extends CassandraSnapshotStoreEndpoint with Cassand
   val cluster = clusterBuilder.build
   val session = cluster.connect()
 
-  if (config.keyspaceAutoCreate) session.execute(createKeyspace)
+  if (config.keyspaceAutoCreate) {
+    retry(config.keyspaceAutoCreateRetries) {
+      session.execute(createKeyspace)
+    }
+  }
   session.execute(createTable)
 
   val preparedWriteSnapshot = session.prepare(writeSnapshot).setConsistencyLevel(writeConsistency)

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -12,6 +12,7 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
   lazy val defaultConfig = ConfigFactory.parseString(
     """
       |keyspace-autocreate = true
+      |keyspace-autocreate-retries = 1
       |keyspace = test-keyspace
       |table = test-table
       |replication-strategy = "SimpleStrategy"


### PR DESCRIPTION
Addressing #49 ConfigurationException: Column family ID mismatch

This pr wraps the schema creation in a retry block to avoid initializationErrors in actors. Default is 'do not retry'.