### PR TITLE
Akka 2.4 snapshot dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ fork in Test := true
 
 javaOptions in Test += "-Xmx2500M"
 
+resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
+
 scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-feature",
@@ -29,8 +31,8 @@ parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.5",
-  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.9",
-  "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.9"   % "test",
+  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.4-SNAPSHOT",
+  "com.typesafe.akka"      %% "akka-persistence-experimental-tck" % "2.4-SNAPSHOT"   % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",
   "org.cassandraunit"       % "cassandra-unit"                    % "2.0.2.2" % "test"
 )

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -45,7 +45,7 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
     }
   }
 
-  def asyncDeleteMessages(messageIds: Seq[MessageId], permanent: Boolean): Future[Unit] = executeBatch { batch =>
+  private def asyncDeleteMessages(messageIds: Seq[MessageId], permanent: Boolean): Future[Unit] = executeBatch { batch =>
     messageIds.foreach { mid =>
       val stmt =
         if (permanent) preparedDeletePermanent.bind(mid.persistenceId, partitionNr(mid.sequenceNr): JLong, mid.sequenceNr: JLong)

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -43,12 +43,6 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
     }
   }
 
-  def asyncWriteConfirmations(confirmations: Seq[PersistentConfirmation]): Future[Unit] = executeBatch { batch =>
-    confirmations.foreach { c =>
-      batch.add((preparedConfirmMessage.bind(c.persistenceId, partitionNr(c.sequenceNr): JLong, c.sequenceNr: JLong, confirmMarker(c.channelId))))
-    }
-  }
-
   def asyncDeleteMessages(messageIds: Seq[PersistentId], permanent: Boolean): Future[Unit] = executeBatch { batch =>
     messageIds.foreach { mid =>
       val stmt =
@@ -84,9 +78,6 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   def persistentFromByteBuffer(b: ByteBuffer): PersistentRepr = {
     serialization.deserialize(Bytes.getArray(b), classOf[PersistentRepr]).get
   }
-
-  private def confirmMarker(channelId: String) =
-    s"C-${channelId}"
 
   override def postStop(): Unit = {
     session.close()

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -38,8 +38,8 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   def asyncWriteMessages(messages: Seq[PersistentRepr]): Future[Unit] = executeBatch { batch =>
     messages.foreach { m =>
       val pnr = partitionNr(m.sequenceNr)
-      if (partitionNew(m.sequenceNr)) batch.add(preparedWriteHeader.bind(m.processorId, pnr: JLong))
-      batch.add(preparedWriteMessage.bind(m.processorId, pnr: JLong, m.sequenceNr: JLong, persistentToByteBuffer(m)))
+      if (partitionNew(m.sequenceNr)) batch.add(preparedWriteHeader.bind(m.persistenceId, pnr: JLong))
+      batch.add(preparedWriteMessage.bind(m.persistenceId, pnr: JLong, m.sequenceNr: JLong, persistentToByteBuffer(m)))
     }
   }
 
@@ -52,16 +52,16 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   def asyncDeleteMessages(messageIds: Seq[PersistentId], permanent: Boolean): Future[Unit] = executeBatch { batch =>
     messageIds.foreach { mid =>
       val stmt =
-        if (permanent) preparedDeletePermanent.bind(mid.processorId, partitionNr(mid.sequenceNr): JLong, mid.sequenceNr: JLong)
-        else preparedDeleteLogical.bind(mid.processorId, partitionNr(mid.sequenceNr): JLong, mid.sequenceNr: JLong)
+        if (permanent) preparedDeletePermanent.bind(mid.persistenceId, partitionNr(mid.sequenceNr): JLong, mid.sequenceNr: JLong)
+        else preparedDeleteLogical.bind(mid.persistenceId, partitionNr(mid.sequenceNr): JLong, mid.sequenceNr: JLong)
       batch.add(stmt)
     }
   }
 
-  def asyncDeleteMessagesTo(processorId: String, toSequenceNr: Long, permanent: Boolean): Future[Unit] = {
-    val fromSequenceNr = readLowestSequenceNr(processorId, 1L)
+  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean): Future[Unit] = {
+    val fromSequenceNr = readLowestSequenceNr(persistenceId, 1L)
     val asyncDeletions = (fromSequenceNr to toSequenceNr).grouped(persistence.settings.journal.maxDeletionBatchSize).map { group =>
-      asyncDeleteMessages(group map (PersistentIdImpl(processorId, _)), permanent)
+      asyncDeleteMessages(group map (PersistentIdImpl(persistenceId, _)), permanent)
     }
     Future.sequence(asyncDeletions).map(_ => ())
   }

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -13,28 +13,28 @@ trait CassandraRecovery { this: CassandraJournal =>
 
   implicit lazy val replayDispatcher = context.system.dispatchers.lookup(replayDispatcherId)
 
-  def asyncReplayMessages(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Future[Unit] =
-    Future { replayMessages(processorId, fromSequenceNr, toSequenceNr, max)(replayCallback) }
+  def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Future[Unit] =
+    Future { replayMessages(persistenceId, fromSequenceNr, toSequenceNr, max)(replayCallback) }
 
-  def asyncReadHighestSequenceNr(processorId: String, fromSequenceNr: Long): Future[Long] =
-    Future { readHighestSequenceNr(processorId, fromSequenceNr ) }
+  def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
+    Future { readHighestSequenceNr(persistenceId, fromSequenceNr ) }
 
-  def readHighestSequenceNr(processorId: String, fromSequenceNr: Long): Long =
-    new MessageIterator(processorId, math.max(1L, fromSequenceNr), Long.MaxValue, Long.MaxValue).foldLeft(fromSequenceNr) { case (acc, msg) => msg.sequenceNr }
+  def readHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long =
+    new MessageIterator(persistenceId, math.max(1L, fromSequenceNr), Long.MaxValue, Long.MaxValue).foldLeft(fromSequenceNr) { case (acc, msg) => msg.sequenceNr }
 
-  def readLowestSequenceNr(processorId: String, fromSequenceNr: Long): Long =
-    new MessageIterator(processorId, fromSequenceNr, Long.MaxValue, Long.MaxValue).find(!_.deleted).map(_.sequenceNr).getOrElse(fromSequenceNr)
+  def readLowestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long =
+    new MessageIterator(persistenceId, fromSequenceNr, Long.MaxValue, Long.MaxValue).find(!_.deleted).map(_.sequenceNr).getOrElse(fromSequenceNr)
 
-  def replayMessages(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Unit =
-    new MessageIterator(processorId, fromSequenceNr, toSequenceNr, max).foreach(replayCallback)
+  def replayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Unit =
+    new MessageIterator(persistenceId, fromSequenceNr, toSequenceNr, max).foreach(replayCallback)
 
   /**
    * Iterator over messages, crossing partition boundaries.
    */
-  class MessageIterator(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long) extends Iterator[PersistentRepr] {
+  class MessageIterator(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long) extends Iterator[PersistentRepr] {
     import PersistentRepr.Undefined
 
-    private val iter = new RowIterator(processorId, fromSequenceNr, toSequenceNr)
+    private val iter = new RowIterator(persistenceId, fromSequenceNr, toSequenceNr)
     private var mcnt = 0L
 
     private var c: PersistentRepr = null
@@ -80,7 +80,7 @@ trait CassandraRecovery { this: CassandraJournal =>
   /**
    * Iterates over rows, crossing partition boundaries.
    */
-  class RowIterator(processorId: String, fromSequenceNr: Long, toSequenceNr: Long) extends Iterator[Row] {
+  class RowIterator(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long) extends Iterator[Row] {
     var currentPnr = partitionNr(fromSequenceNr)
     var currentSnr = fromSequenceNr
 
@@ -90,8 +90,8 @@ trait CassandraRecovery { this: CassandraJournal =>
     var rcnt = 0
     var iter = newIter()
 
-    def hasHeader = !session.execute(preparedSelectHeader.bind(processorId, currentPnr: JLong)).isExhausted
-    def newIter() = session.execute(preparedSelectMessages.bind(processorId, currentPnr: JLong, fromSnr: JLong, toSnr: JLong)).iterator
+    def hasHeader = !session.execute(preparedSelectHeader.bind(persistenceId, currentPnr: JLong)).isExhausted
+    def newIter() = session.execute(preparedSelectMessages.bind(persistenceId, currentPnr: JLong, fromSnr: JLong, toSnr: JLong)).iterator
 
     @annotation.tailrec
     final def hasNext: Boolean = {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -69,9 +69,6 @@ trait CassandraRecovery { this: CassandraJournal =>
           if (snr == c.sequenceNr) c = m else n = m
         } else if (marker == "B" && c.sequenceNr == snr) {
           c = c.update(deleted = true)
-        } else if (c.sequenceNr == snr) {
-          val channelId = marker.substring(2)
-          c = c.update(confirms = channelId +: c.confirms)
         }
       }
     }

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -10,53 +10,53 @@ trait CassandraStatements {
 
   def createTable = s"""
       CREATE TABLE IF NOT EXISTS ${tableName} (
-        processor_id text,
+        persistence_id text,
         partition_nr bigint,
         sequence_nr bigint,
         marker text,
         message blob,
-        PRIMARY KEY ((processor_id, partition_nr), sequence_nr, marker))
+        PRIMARY KEY ((persistence_id, partition_nr), sequence_nr, marker))
         WITH COMPACT STORAGE
          AND gc_grace_seconds =${config.gc_grace_seconds}
     """
 
   def writeHeader = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
       VALUES (?, ?, 0, 'H', 0x00)
     """
 
   def writeMessage = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
       VALUES (?, ?, ?, 'A', ?)
     """
 
   def confirmMessage = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
       VALUES (?, ?, ?, ?, 0x00)
     """
 
   def deleteMessageLogical = s"""
-      INSERT INTO ${tableName} (processor_id, partition_nr, sequence_nr, marker, message)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
       VALUES (?, ?, ?, 'B', 0x00)
     """
 
   def deleteMessagePermanent = s"""
       DELETE FROM ${tableName} WHERE
-        processor_id = ? AND
+        persistence_id = ? AND
         partition_nr = ? AND
         sequence_nr = ?
     """
 
   def selectHeader = s"""
       SELECT * FROM ${tableName} WHERE
-        processor_id = ? AND
+        persistence_id = ? AND
         partition_nr = ? AND
         sequence_nr = 0
     """
 
   def selectMessages = s"""
       SELECT * FROM ${tableName} WHERE
-        processor_id = ? AND
+        persistence_id = ? AND
         partition_nr = ? AND
         sequence_nr >= ? AND
         sequence_nr <= ?


### PR DESCRIPTION
This PR comes from a desire to use the akka persistence cassandra journal plugin in combination with akka 2.4 (snapshot).Of course we're going to experiment locally, but perhaps others are interested as well. It's also a trigger to get some feedback on our approach :-)

Note:
In line with the rename of processorId to persistenceId in Akka 2.4, we also changed the column name processor_id to persistence_id in the table definition. Hence this requires a small migration when this version is going to be used with existing data.