### PR TITLE
Keep token aware policy when local DC is specified

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -2,7 +2,7 @@ package akka.persistence.cassandra
 
 import java.net.InetSocketAddress
 
-import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
+import com.datastax.driver.core.policies.{TokenAwarePolicy, DCAwareRoundRobinPolicy}
 import com.datastax.driver.core.{Cluster, ConsistencyLevel, SSLOptions}
 import com.typesafe.config.Config
 
@@ -40,7 +40,9 @@ class CassandraPluginConfig(config: Config) {
 
   if (config.hasPath("local-datacenter")) {
     clusterBuilder.withLoadBalancingPolicy(
-      new DCAwareRoundRobinPolicy(config.getString("local-datacenter"))
+      new TokenAwarePolicy(
+        new DCAwareRoundRobinPolicy(config.getString("local-datacenter"))
+      )
     )
   }
 


### PR DESCRIPTION
Token aware is the default but we need to add it in manually if we override, otherwise the driver will round robin every node in the local DC.