### PR TITLE
WIP: Issue 48 atomic updates

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -2,36 +2,59 @@ package akka.persistence.cassandra.journal
 
 import java.lang.{ Long => JLong }
 
+import akka.actor.ActorLogging
+
 import scala.concurrent._
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ResultSet, Row}
 
 import akka.persistence.PersistentRepr
 
-trait CassandraRecovery { this: CassandraJournal =>
+trait CassandraRecovery extends ActorLogging {
+  this: CassandraJournal =>
   import config._
 
   implicit lazy val replayDispatcher = context.system.dispatchers.lookup(replayDispatcherId)
 
-  def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Future[Unit] =
-    Future { replayMessages(persistenceId, fromSequenceNr, toSequenceNr, max)(replayCallback) }
+  def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Future[Unit] = {
+    log.debug("asyncReplyMessages {} {} {} {}", persistenceId, fromSequenceNr, toSequenceNr, max)
+    Future {
+      replayMessages(persistenceId, fromSequenceNr, toSequenceNr, max)(replayCallback)
+    }
+  }
 
-  def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
-    Future { readHighestSequenceNr(persistenceId, fromSequenceNr ) }
+  def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
+    log.debug("asyncReadHighestSequenceNr {} {}", persistenceId, fromSequenceNr)
+    Future {
+      readHighestSequenceNr(persistenceId, fromSequenceNr)
+    }
+  }
 
-  def readHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long =
-    new MessageIterator(persistenceId, math.max(1L, fromSequenceNr), Long.MaxValue, Long.MaxValue).foldLeft(fromSequenceNr) { case (acc, msg) => msg.sequenceNr }
+  def readHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long = {
+    log.debug("readHighestSequenceNr {} {}", persistenceId, fromSequenceNr)
+    val result = new MessageIterator(persistenceId, math.max(1L, fromSequenceNr), Long.MaxValue, Long.MaxValue).foldLeft(fromSequenceNr) { case (acc, msg) => msg.sequenceNr }
+    log.debug(s"Highest sequence number $result")
+    result
+  }
 
-  def readLowestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long =
+  def readLowestSequenceNr(persistenceId: String, fromSequenceNr: Long): Long = {
+    log.debug("readLowestSequenceNr {} {}", persistenceId, fromSequenceNr)
     new MessageIterator(persistenceId, fromSequenceNr, Long.MaxValue, Long.MaxValue).find(!_.deleted).map(_.sequenceNr).getOrElse(fromSequenceNr)
+  }
 
-  def replayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Unit =
-    new MessageIterator(persistenceId, fromSequenceNr, toSequenceNr, max).foreach(replayCallback)
+  def replayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: (PersistentRepr) => Unit): Unit = {
+    log.debug("replayMessages {} {} {} {}", persistenceId, fromSequenceNr, toSequenceNr, max)
+    new MessageIterator(persistenceId, fromSequenceNr, toSequenceNr, max).foreach( msg => {
+      log.debug(s"Replaying $msg")
+      replayCallback(msg)
+    })
+  }
 
   /**
    * Iterator over messages, crossing partition boundaries.
    */
   class MessageIterator(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long) extends Iterator[PersistentRepr] {
+
     import PersistentRepr.Undefined
 
     private val iter = new RowIterator(persistenceId, fromSequenceNr, toSequenceNr)
@@ -53,23 +76,18 @@ trait CassandraRecovery { this: CassandraJournal =>
 
     /**
      * Make next message n the current message c, complete c
-     * (ignoring orphan markers) and pre-fetch new n.
+     * and pre-fetch new n.
      */
     private def fetch(): Unit = {
       c = n
       n = null
       while (iter.hasNext && n == null) {
         val row = iter.next()
-        val marker = row.getString("marker")
         val snr = row.getLong("sequence_nr")
-        if (marker == "A") {
-          val m = persistentFromByteBuffer(row.getBytes("message"))
-          // there may be duplicates returned by iter
-          // (on scan boundaries within a partition)
-          if (snr == c.sequenceNr) c = m else n = m
-        } else if (marker == "B" && c.sequenceNr == snr) {
-          c = c.update(deleted = true)
-        }
+        val m = persistentFromByteBuffer(row.getBytes("message"))
+        // there may be duplicates returned by iter
+        // (on scan boundaries within a partition)
+        if (snr == c.sequenceNr) c = m else n = m
       }
     }
   }
@@ -82,32 +100,48 @@ trait CassandraRecovery { this: CassandraJournal =>
     var currentSnr = fromSequenceNr
 
     var fromSnr = fromSequenceNr
-    var toSnr = math.min(sequenceNrMax(currentPnr), toSequenceNr)
+    var toSnr = toSequenceNr
 
     var rcnt = 0
     var iter = newIter()
 
-    def hasHeader = !session.execute(preparedSelectHeader.bind(persistenceId, currentPnr: JLong)).isExhausted
-    def newIter() = session.execute(preparedSelectMessages.bind(persistenceId, currentPnr: JLong, fromSnr: JLong, toSnr: JLong)).iterator
+    def newIter() = {
+      log.debug(s"id=$persistenceId partition=$currentPnr from=$fromSnr to=$toSnr")
+      session.execute(preparedSelectMessages.bind(persistenceId, currentPnr: JLong, fromSnr: JLong, toSnr: JLong)).iterator
+    }
+
+    def inUse: Boolean = {
+      val execute: ResultSet = session.execute(preparedCheckInUse.bind(persistenceId, currentPnr: JLong))
+      if (execute.isExhausted) {
+        false
+      } else {
+        val used = execute.one().getBool("used")
+        log.debug(s"In use partition $currentPnr : $used")
+        used
+      }
+
+    }
 
     @annotation.tailrec
     final def hasNext: Boolean = {
       if (iter.hasNext) {
-        // more entries available in current partition
+        // more entries available in current resultset
         true
-      } else if (rcnt == 0 && !hasHeader) {
-        // no more entries available, non-existing partition detected
+      } else if (rcnt == 0 && !inUse) {
+        // empty partition and inUse not set, empty partitions are a result of deletions or large persistAll calls
+        log.debug(s"Empty partition and not in use $currentPnr")
         false
       } else if (rcnt < maxResultSize) {
         // all entries consumed, try next partition
         currentPnr += 1
-        fromSnr = sequenceNrMin(currentPnr)
-        toSnr = math.min(sequenceNrMax(currentPnr), toSequenceNr)
+        log.debug(s"Moving to partition $currentPnr")
+        fromSnr = currentSnr
         rcnt = 0
         iter = newIter()
         hasNext
       } else {
-        // max result set size reached, continue with same partition
+        // max result set size reached, continue with same partition moving the fromSnr forward
+        log.debug(s"Max results size reached, moving along a partition $currentPnr")
         fromSnr = currentSnr
         rcnt = 0
         iter = newIter()

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -10,29 +10,23 @@ trait CassandraStatements {
 
   def createTable = s"""
       CREATE TABLE IF NOT EXISTS ${tableName} (
+        used boolean static,
         persistence_id text,
         partition_nr bigint,
         sequence_nr bigint,
-        marker text,
         message blob,
-        PRIMARY KEY ((persistence_id, partition_nr), sequence_nr, marker))
-        WITH COMPACT STORAGE
-         AND gc_grace_seconds =${config.gc_grace_seconds}
-    """
-
-  def writeHeader = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, 0, 'H', 0x00)
+        PRIMARY KEY ((persistence_id, partition_nr), sequence_nr))
+        WITH gc_grace_seconds =${config.gc_grace_seconds}
     """
 
   def writeMessage = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, ?, 'A', ?)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, message, used)
+      VALUES (?, ?, ?, ?, true)
     """
 
   def confirmMessage = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, marker, message)
-      VALUES (?, ?, ?, ?, 0x00)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, message)
+      VALUES (?, ?, ?, 0x00)
     """
 
   def deleteMessage = s"""
@@ -40,13 +34,6 @@ trait CassandraStatements {
         persistence_id = ? AND
         partition_nr = ? AND
         sequence_nr = ?
-    """
-
-  def selectHeader = s"""
-      SELECT * FROM ${tableName} WHERE
-        persistence_id = ? AND
-        partition_nr = ? AND
-        sequence_nr = 0
     """
 
   def selectMessages = s"""
@@ -58,5 +45,17 @@ trait CassandraStatements {
         LIMIT ${config.maxResultSize}
     """
 
+  def selectInUse =
+    s"""
+       SELECT used from ${tableName}
+       WHERE persistence_id = ? AND
+       partition_nr = ?
+     """
+
+  def writeInUse =
+    s"""
+       INSERT INTO ${tableName} (persistence_id, partition_nr, used)
+       VALUES(?, ?, true)
+     """
   private def tableName = s"${config.keyspace}.${config.table}"
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,7 +8,10 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <logger name="org.apache.cassandra" level="ERROR" />
+    <logger name="com.datastax.driver.core" level="WARN" />
+
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
 

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -1,5 +1,7 @@
 package akka.persistence.cassandra.journal
 
+import java.util.UUID
+
 import scala.concurrent.duration._
 
 import akka.actor._
@@ -27,6 +29,24 @@ object CassandraIntegrationSpec {
     """.stripMargin)
 
   case class DeleteTo(snr: Long)
+
+  class ProcessorAtomic(val persistenceId: String, receiver: ActorRef) extends PersistentActor {
+    def receiveRecover: Receive = handle
+
+    def receiveCommand: Receive = {
+      case DeleteTo(sequenceNr) =>
+        deleteMessages(sequenceNr)
+      case payload: List[_] =>
+        persistAll(payload)(handle)
+    }
+
+    def handle: Receive = {
+      case payload: String =>
+        receiver ! payload
+        receiver ! lastSequenceNr
+        receiver ! recoveryRunning
+    }
+  }
 
   class ProcessorA(val persistenceId: String, receiver: ActorRef) extends PersistentActor {
     def receiveRecover: Receive = handle
@@ -131,13 +151,14 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
 
   "A Cassandra journal" should {
     "write and replay messages" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p1", self))
+      val persistenceId = UUID.randomUUID().toString
+      val processor1 = system.actorOf(Props(classOf[ProcessorA], persistenceId, self), "p1")
       1L to 16L foreach { i =>
         processor1 ! s"a-${i}"
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorA], "p1", self))
+      val processor2 = system.actorOf(Props(classOf[ProcessorA], persistenceId, self), "p2")
       1L to 16L foreach { i =>
         expectMsgAllOf(s"a-${i}", i, true)
       }
@@ -146,17 +167,19 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       expectMsgAllOf("b", 17L, false)
     }
     "not replay range-deleted messages" in {
-      testRangeDelete("p6")
+      val persistenceId = UUID.randomUUID().toString
+      testRangeDelete(persistenceId)
     }
     "replay messages incrementally" in {
+      val persistenceId = UUID.randomUUID().toString
       val probe = TestProbe()
-      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p7", self))
+      val processor1 = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
       1L to 6L foreach { i =>
         processor1 ! s"a-${i}"
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
-      val view = system.actorOf(Props(classOf[ViewA], "p7-view", "p7", probe.ref))
+      val view = system.actorOf(Props(classOf[ViewA], "p7-view", persistenceId, probe.ref))
       probe.expectNoMsg(200.millis)
 
       view ! Update(await = true, replayMax = 3L)
@@ -171,11 +194,64 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       probe.expectMsg(s"a-6")
       probe.expectNoMsg(200.millis)
     }
+    "write and replay with persistAll greater than partition size skipping whole partition" in {
+      val persistenceId = UUID.randomUUID().toString
+      val probe = TestProbe()
+      val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
+
+      processorAtomic ! List("a-1", "a-2", "a-3", "a-4", "a-5", "a-6")
+      1L to 6L foreach { i =>
+        expectMsgAllOf(s"a-${i}", i, false)
+      }
+
+      val testProbe = TestProbe()
+      val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
+      1L to 6L foreach { i =>
+        testProbe.expectMsgAllOf(s"a-${i}", i, true)
+      }
+    }
+    "write and replay with persistAll greater than partition size skipping part of a partition" in {
+      val persistenceId = UUID.randomUUID().toString
+      val probe = TestProbe()
+      val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
+
+      processorAtomic ! List("a-1", "a-2", "a-3")
+      1L to 3L foreach { i =>
+        expectMsgAllOf(s"a-${i}", i, false)
+      }
+
+      processorAtomic ! List("a-4", "a-5", "a-6")
+      4L to 6L foreach { i =>
+        expectMsgAllOf(s"a-${i}", i, false)
+      }
+
+      val testProbe = TestProbe()
+      val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
+      1L to 6L foreach { i =>
+        testProbe.expectMsgAllOf(s"a-${i}", i, true)
+      }
+    }
+    "write and replay with persistAll less than partition size" in {
+      val persistenceId = UUID.randomUUID().toString
+      val probe = TestProbe()
+      val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
+
+      processorAtomic ! List("a-1", "a-2", "a-3", "a-4")
+      1L to 4L foreach { i =>
+        expectMsgAllOf(s"a-${i}", i, false)
+      }
+
+      val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
+      1L to 4L foreach { i =>
+        expectMsgAllOf(s"a-${i}", i, true)
+      }
+    }
   }
 
   "A processor" should {
     "recover from a snapshot with follow-up messages" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorC], "p10", testActor))
+      val persistenceId = UUID.randomUUID().toString
+      val processor1 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       processor1 ! "a"
       expectMsg("updated-a-1")
       processor1 ! "snap"
@@ -183,12 +259,13 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor1 ! "b"
       expectMsg("updated-b-2")
 
-      system.actorOf(Props(classOf[ProcessorC], "p10", testActor))
+      system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       expectMsg("updated-b-2")
     }
     "recover from a snapshot with follow-up messages and an upper bound" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorCNoRecover], "p11", testActor))
+      val persistenceId = UUID.randomUUID().toString
+      val processor1 = system.actorOf(Props(classOf[ProcessorCNoRecover], persistenceId, testActor))
       processor1 ! Recover()
       processor1 ! "a"
       expectMsg("updated-a-1")
@@ -199,7 +276,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
         expectMsg(s"updated-a-${i}")
       }
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorCNoRecover], "p11", testActor))
+      val processor2 = system.actorOf(Props(classOf[ProcessorCNoRecover], persistenceId, testActor))
       processor2 ! Recover(toSequenceNr = 3L)
       expectMsg("offered-a-1")
       expectMsg("updated-a-2")
@@ -208,19 +285,21 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       expectMsg("updated-d-8")
     }
     "recover from a snapshot without follow-up messages inside a partition" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorC], "p12", testActor))
+      val persistenceId = UUID.randomUUID().toString
+      val processor1 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       processor1 ! "a"
       expectMsg("updated-a-1")
       processor1 ! "snap"
       expectMsg("snapped-a-1")
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorC], "p12", testActor))
+      val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       processor2 ! "b"
       expectMsg("updated-b-2")
     }
     "recover from a snapshot without follow-up messages at a partition boundary (where next partition is invalid)" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorC], "p13", testActor))
+      val persistenceId = UUID.randomUUID().toString
+      val processor1 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       1L to 5L foreach { i =>
         processor1 ! "a"
         expectMsg(s"updated-a-${i}")
@@ -228,16 +307,17 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor1 ! "snap"
       expectMsg("snapped-a-5")
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorC], "p13", testActor))
+      val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
       expectMsg("updated-b-6")
     }
     "recover from a snapshot without follow-up messages at a partition boundary (where next partition contains a permanently deleted message)" in {
+      val persistenceId = UUID.randomUUID().toString
       val deleteProbe = TestProbe()
       subscribeToRangeDeletion(deleteProbe)
 
-      val processor1 = system.actorOf(Props(classOf[ProcessorC], "p15", testActor))
+      val processor1 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       1L to 5L foreach { i =>
         processor1 ! "a"
         expectMsg(s"updated-a-${i}")
@@ -251,16 +331,17 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor1 ! DeleteTo(6L)
       awaitRangeDeletion(deleteProbe)
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorC], "p15", testActor))
+      val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
       expectMsg("updated-b-6") // sequence number of permanently deleted message can be re-used
     }
     "properly recover after all messages have been deleted" in {
+      val persistenceId = UUID.randomUUID().toString
       val deleteProbe = TestProbe()
       subscribeToRangeDeletion(deleteProbe)
 
-      val p = system.actorOf(Props(classOf[ProcessorA], "p16", self))
+      val p = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
 
       p ! "a"
       expectMsgAllOf("a", 1L, false)
@@ -268,7 +349,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       p ! DeleteTo(1L)
       awaitRangeDeletion(deleteProbe)
 
-      val r = system.actorOf(Props(classOf[ProcessorA], "p16", self))
+      val r = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
 
       r ! "b"
       expectMsgAllOf("b", 1L, false)


### PR DESCRIPTION
Hi @krasserm - this will needs some clean up I just wanted some feedback / early discussions on the schema changes. I'll remove all the logging I was just 100% checking that I understood how/when akka-persistence called into the plugin.

I removed marker and added a static boolean column called inUse. This will be set on any write and when we skip an entire partition due to a large persistAll. This is used for scans (like the marker used to be) to make sure we keep scanning if entire partitions have been deleted or skipped.

I removed COMPACT STORAGE as this will limit our future schema changes and the space issue is being addressed in the next version of Cassandra (https://issues.apache.org/jira/browse/CASSANDRA-8099). 

For atomicity I went with a similar approach to discussed on the issue:
1) If an AtomicWrite spans a partition it is put in the higher partition
2) Fail fast if someone tries to persist an atomic event that spans 3 partitions. Knowing a sequence number can only be in one partition greater than it should be makes finding easier. I'll be impressed if someone tries to persist an AtomicWrite that is 5-10M in size :)

So the trade off is that we may end up with slightly varied partition sizes but I don't see that as an issue and will only be noticeable if people have huge AtomicWrites. 

TODO:
- Handle deletes for seqNr that got moved to the next partition. We'll either need to read then write to see where it is or delete both possible locations WDYT? I generally try and avoid read and writes due to the race conditions and bad perf due to round trips but the double delete adds unnecessary tombstones. 

Couple other things:
- Changes the tests to use UUIDs as persistenceIds as I kept adding tests in the middle :)