### PR TITLE
Chagnes for akka 2.4-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-deprecation",
-  //"-Xfatal-warnings",
+  "-Xfatal-warnings",
   "-Xlint",
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
@@ -28,9 +28,9 @@ scalacOptions ++= Seq(
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.5",
-  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.3.11",
-  "com.typesafe.akka"      %% "akka-persistence-tck-experimental" % "2.3.11"  % "test",
-  "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",
-  "org.cassandraunit"       % "cassandra-unit"                    % "2.0.2.2" % "test"
+  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.7",
+  "com.typesafe.akka"      %% "akka-persistence-experimental"     % "2.4-M2",
+  "com.typesafe.akka"      %% "akka-persistence-experimental-tck" % "2.4-M2"  % "test",
+  "org.scalatest"          %% "scalatest"                         % "2.2.4"   % "test",
+  "org.cassandraunit"       % "cassandra-unit"                    % "2.1.3.1" % "test"
 )

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -69,9 +69,6 @@ trait CassandraRecovery { this: CassandraJournal =>
           if (snr == c.sequenceNr) c = m else n = m
         } else if (marker == "B" && c.sequenceNr == snr) {
           c = c.update(deleted = true)
-        } else if (c.sequenceNr == snr) {
-          val channelId = marker.substring(2)
-          c = c.update(confirms = channelId +: c.confirms)
         }
       }
     }

--- a/src/test/resources/application-test.conf
+++ b/src/test/resources/application-test.conf
@@ -1,0 +1,6 @@
+akka.persistence.journal.plugin = "cassandra-journal"
+akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
+akka.test.single-expect-default = 10s
+cassandra-journal.port = 9142
+cassandra-snapshot-store.port = 9142
+cassandra-snapshot-store.max-metadata-result-size = 2

--- a/src/test/scala/akka/persistence/cassandra/TestConfig.scala
+++ b/src/test/scala/akka/persistence/cassandra/TestConfig.scala
@@ -1,0 +1,8 @@
+package akka.persistence.cassandra
+
+import com.typesafe.config.ConfigFactory
+
+object TestConfig {
+
+  val config = ConfigFactory.parseResources("application-test.conf")
+}

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -1,5 +1,7 @@
 package akka.persistence.cassandra.journal
 
+import akka.persistence.cassandra.TestConfig
+
 import scala.concurrent.duration._
 
 import akka.actor._
@@ -14,39 +16,30 @@ import org.scalatest._
 object CassandraIntegrationSpec {
   val config = ConfigFactory.parseString(
     """
-      |akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
-      |akka.persistence.journal.plugin = "cassandra-journal"
       |akka.persistence.journal.max-deletion-batch-size = 3
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
-      |akka.test.single-expect-default = 10s
       |cassandra-journal.max-partition-size = 5
       |cassandra-journal.max-result-size = 3
-      |cassandra-journal.port = 9142
-      |cassandra-snapshot-store.port = 9142
-    """.stripMargin)
+    """.stripMargin).withFallback(TestConfig.config)
 
-  case class Delete(snr: Long, permanent: Boolean)
+  case class DeleteTo(snr: Long)
 
-  case class DeleteTo(snr: Long, permanent: Boolean)
-
-  class ProcessorA(val persistenceId: String) extends PersistentActor {
+  class ProcessorA(val persistenceId: String, replyTo: ActorRef) extends PersistentActor {
     def receiveRecover: Receive = handle
 
     def receiveCommand: Receive = {
-      case Delete(sequenceNr, permanent) =>
-        deleteMessage(sequenceNr, permanent)
-      case DeleteTo(sequenceNr, permanent) =>
-        deleteMessages(sequenceNr, permanent)
+      case DeleteTo(sequenceNr) =>
+        deleteMessages(sequenceNr)
       case payload: String =>
         persist(payload)(handle)
     }
 
     def handle: Receive = {
       case payload: String =>
-        sender ! payload
-        sender ! lastSequenceNr
-        sender ! recoveryRunning
+        replyTo ! payload
+        replyTo ! lastSequenceNr
+        replyTo ! recoveryRunning
     }
   }
 
@@ -66,8 +59,8 @@ object CassandraIntegrationSpec {
         saveSnapshot(last)
       case SaveSnapshotSuccess(_) =>
         probe ! s"snapped-${last}"
-      case Delete(sequenceNr, permanent) =>
-        deleteMessage(sequenceNr, permanent)
+      case DeleteTo(sequenceNr) =>
+        deleteMessages(sequenceNr)
       case payload: String =>
         persist(payload)(handle)
 
@@ -100,77 +93,35 @@ object CassandraIntegrationSpec {
 import CassandraIntegrationSpec._
 
 class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with ImplicitSender with WordSpecLike with Matchers with CassandraLifecycle {
-  def subscribeToConfirmation(probe: TestProbe): Unit =
-    system.eventStream.subscribe(probe.ref, classOf[Delivered])
-
-  def subscribeToBatchDeletion(probe: TestProbe): Unit =
-    system.eventStream.subscribe(probe.ref, classOf[JournalProtocol.DeleteMessages])
 
   def subscribeToRangeDeletion(probe: TestProbe): Unit =
     system.eventStream.subscribe(probe.ref, classOf[JournalProtocol.DeleteMessagesTo])
 
-  def awaitBatchDeletion(probe: TestProbe): Unit =
-    probe.expectMsgType[JournalProtocol.DeleteMessages]
-
   def awaitRangeDeletion(probe: TestProbe): Unit =
     probe.expectMsgType[JournalProtocol.DeleteMessagesTo]
 
-  def testIndividualDelete(processorId: String, permanent: Boolean): Unit = {
-    val deleteProbe = TestProbe()
-    subscribeToBatchDeletion(deleteProbe)
-
-    val processor1 = system.actorOf(Props(classOf[ProcessorA], processorId))
-    1L to 16L foreach { i =>
-      processor1 ! s"a-${i}"
-      expectMsgAllOf(s"a-${i}", i, false)
-    }
-
-    // delete single message in partition
-    processor1 ! Delete(12L, permanent)
-    awaitBatchDeletion(deleteProbe)
-
-    system.actorOf(Props(classOf[ProcessorA], processorId))
-    1L to 16L foreach { i =>
-      if (i != 12L) expectMsgAllOf(s"a-${i}", i, true)
-    }
-
-    // delete whole partition
-    6L to 10L foreach { i =>
-      processor1 ! Delete(i, permanent)
-      awaitBatchDeletion(deleteProbe)
-    }
-
-    system.actorOf(Props(classOf[ProcessorA], processorId))
-    1L to 5L foreach { i =>
-      expectMsgAllOf(s"a-${i}", i, true)
-    }
-    11L to 16L foreach { i =>
-      if (i != 12L) expectMsgAllOf(s"a-${i}", i, true)
-    }
-  }
-
-  def testRangeDelete(processorId: String, permanent: Boolean): Unit = {
+  def testRangeDelete(processorId: String): Unit = {
     val deleteProbe = TestProbe()
     subscribeToRangeDeletion(deleteProbe)
 
-    val processor1 = system.actorOf(Props(classOf[ProcessorA], processorId))
+    val processor1 = system.actorOf(Props(classOf[ProcessorA], processorId, testActor))
     1L to 16L foreach { i =>
       processor1 ! s"a-${i}"
       expectMsgAllOf(s"a-${i}", i, false)
     }
 
-    processor1 ! DeleteTo(3L, permanent)
+    processor1 ! DeleteTo(3L)
     awaitRangeDeletion(deleteProbe)
 
-    system.actorOf(Props(classOf[ProcessorA], processorId))
+    system.actorOf(Props(classOf[ProcessorA], processorId, testActor))
     4L to 16L foreach { i =>
       expectMsgAllOf(s"a-${i}", i, true)
     }
 
-    processor1 ! DeleteTo(7L, permanent)
+    processor1 ! DeleteTo(7L)
     awaitRangeDeletion(deleteProbe)
 
-    system.actorOf(Props(classOf[ProcessorA], processorId))
+    system.actorOf(Props(classOf[ProcessorA], processorId, testActor))
     8L to 16L foreach { i =>
       expectMsgAllOf(s"a-${i}", i, true)
     }
@@ -178,13 +129,13 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
 
   "A Cassandra journal" should {
     "write and replay messages" in {
-      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p1"))
+      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p1", testActor))
       1L to 16L foreach { i =>
         processor1 ! s"a-${i}"
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
-      val processor2 = system.actorOf(Props(classOf[ProcessorA], "p1"))
+      val processor2 = system.actorOf(Props(classOf[ProcessorA], "p1", testActor))
       1L to 16L foreach { i =>
         expectMsgAllOf(s"a-${i}", i, true)
       }
@@ -192,21 +143,12 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor2 ! "b"
       expectMsgAllOf("b", 17L, false)
     }
-    "not replay messages marked as deleted" in {
-      testIndividualDelete("p3", false)
-    }
-    "not replay permanently deleted messages" in {
-      testIndividualDelete("p4", true)
-    }
-    "not replay messages marked as range-deleted" in {
-      testRangeDelete("p5", false)
-    }
     "not replay permanently range-deleted messages" in {
-      testRangeDelete("p6", true)
+      testRangeDelete("p6")
     }
     "replay messages incrementally" in {
       val probe = TestProbe()
-      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p7"))
+      val processor1 = system.actorOf(Props(classOf[ProcessorA], "p7", testActor))
       1L to 6L foreach { i =>
         processor1 ! s"a-${i}"
         expectMsgAllOf(s"a-${i}", i, false)
@@ -291,7 +233,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
     }
     "recover from a snapshot without follow-up messages at a partition boundary (where next partition contains a message marked as deleted)" in {
       val deleteProbe = TestProbe()
-      subscribeToBatchDeletion(deleteProbe)
+      subscribeToRangeDeletion(deleteProbe)
 
       val processor1 = system.actorOf(Props(classOf[ProcessorC], "p14", testActor))
       1L to 5L foreach { i =>
@@ -304,17 +246,17 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor1 ! "a"
       expectMsg("updated-a-6")
 
-      processor1 ! Delete(6L, false)
-      awaitBatchDeletion(deleteProbe)
+      processor1 ! DeleteTo(6L)
+      awaitRangeDeletion(deleteProbe)
 
       val processor2 = system.actorOf(Props(classOf[ProcessorC], "p14", testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
-      expectMsg("updated-b-7")
+      expectMsg("updated-b-6")
     }
     "recover from a snapshot without follow-up messages at a partition boundary (where next partition contains a permanently deleted message)" in {
       val deleteProbe = TestProbe()
-      subscribeToBatchDeletion(deleteProbe)
+      subscribeToRangeDeletion(deleteProbe)
 
       val processor1 = system.actorOf(Props(classOf[ProcessorC], "p15", testActor))
       1L to 5L foreach { i =>
@@ -327,8 +269,8 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       processor1 ! "a"
       expectMsg("updated-a-6")
 
-      processor1 ! Delete(6L, true)
-      awaitBatchDeletion(deleteProbe)
+      processor1 ! DeleteTo(6L)
+      awaitRangeDeletion(deleteProbe)
 
       val processor2 = system.actorOf(Props(classOf[ProcessorC], "p15", testActor))
       expectMsg("offered-a-5")
@@ -337,17 +279,17 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
     }
     "properly recover after all messages have been deleted" in {
       val deleteProbe = TestProbe()
-      subscribeToBatchDeletion(deleteProbe)
+      subscribeToRangeDeletion(deleteProbe)
 
-      val p = system.actorOf(Props(classOf[ProcessorA], "p16"))
+      val p = system.actorOf(Props(classOf[ProcessorA], "p16", testActor))
 
       p ! "a"
       expectMsgAllOf("a", 1L, false)
 
-      p ! Delete(1L, true)
-      awaitBatchDeletion(deleteProbe)
+      p ! DeleteTo(1L)
+      awaitRangeDeletion(deleteProbe)
 
-      val r = system.actorOf(Props(classOf[ProcessorA], "p16"))
+      val r = system.actorOf(Props(classOf[ProcessorA], "p16", testActor))
 
       r ! "b"
       expectMsgAllOf("b", 1L, false)

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -1,23 +1,12 @@
 package akka.persistence.cassandra.journal
 
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.TestConfig
+import akka.persistence.journal.JournalPerfSpec
+
 import scala.concurrent.duration._
 
-import akka.persistence.journal._
-import akka.persistence.cassandra.CassandraLifecycle
-
-import com.typesafe.config.ConfigFactory
-
-import org.scalatest.BeforeAndAfterAll
-
-class CassandraJournalSpec extends JournalSpec with JournalPerfSpec with BeforeAndAfterAll with CassandraLifecycle {
-  lazy val config = ConfigFactory.parseString(
-    """
-      |akka.persistence.journal.plugin = "cassandra-journal"
-      |akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
-      |akka.test.single-expect-default = 10s
-      |cassandra-journal.port = 9142
-      |cassandra-snapshot-store.port = 9142
-    """.stripMargin)
+class CassandraJournalSpec extends JournalPerfSpec(TestConfig.config) with CassandraLifecycle {
 
   override def awaitDurationMillis: Long = 20.seconds.toMillis
 }

--- a/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -6,22 +6,13 @@ import java.nio.ByteBuffer
 import akka.persistence._
 import akka.persistence.SnapshotProtocol._
 import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.TestConfig
 import akka.persistence.snapshot.SnapshotStoreSpec
 import akka.testkit.TestProbe
 
 import com.datastax.driver.core._
-import com.typesafe.config.ConfigFactory
 
-class CassandraSnapshotStoreSpec extends SnapshotStoreSpec with CassandraLifecycle {
-  lazy val config = ConfigFactory.parseString(
-    """
-      |akka.persistence.journal.plugin = "cassandra-journal"
-      |akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
-      |akka.test.single-expect-default = 10s
-      |cassandra-journal.port = 9142
-      |cassandra-snapshot-store.port = 9142
-      |cassandra-snapshot-store.max-metadata-result-size = 2
-    """.stripMargin)
+class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(TestConfig.config) with CassandraLifecycle {
 
   val storeConfig = new CassandraSnapshotStoreConfig(system.settings.config.getConfig("cassandra-snapshot-store"))
   val storeStatements = new CassandraStatements { def config = storeConfig }


### PR DESCRIPTION
Hello,

this is my humble attempt at trying to make plugin work with akka-2.4-M2. I removed methods which are gone from 2.4 and changes tests. I had to pass sender to persistent actors to make them work, honestly I don't understand how they worked before, was `sender` automatically saved previously? Also there is some strange thing with 'akka-persistence-experimental-tck' package, as name changed from 'akka-persistence-tck-experimental', not sure if it is for 2.4-M2 release only or for whole 2.4