### PR TITLE
Issue 77 - Persistence Query for Cassandra design discussion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ To connect to the Cassandra host with SSL enabled, add the following configurati
 To limit the Cassandra hosts this plugin connects with to a specific datacenter, use the following setting:
 
 - `cassandra-snapshot-store.local-datacenter`.  The id for the local datacenter of the Cassandra hosts that this module should connect to.  By default, this property is not set resulting in Datastax's standard round robin policy being used.
+


### PR DESCRIPTION
##### Do not merge. #####

I have done a few iterations on the Persistence Query api implementation for Cassandra and before spending too much time on it I wanted to discuss possible implementations, because I still don't clearly understand all the implications.

Please have a look at the below and provide feedback, ideas and let me know where I am wrong. When we are happy with the design I will work on the actual implementation and publish the results along the way.

##### Assumptions #####
I am not aware of any exposed api for streams subscription in Cassandra so we will have to pull (query the database in configured intervals) or push from write side (see below).

The Cassandra read journal is different from the reference LevelDB read journal, because we it can be distributed and therefore we can not trivially assume shared knowledge.


##### Implementation #####
I can think of two options how to implement the read query api given the above assumptions.

###### 1) Pull only approach ######
CassandraReadJournal would be very similar to LevelDBReadJournal. It would examine the query, parameters and create actor for each query that represents the source. There may be a few potential optimizations (e.g. for not updating queries creating source from iterator provided by Cassandra). Generally however we need to create an actor, because it needs to manage the current state of the stream. By state of the stream I mean the management of already seen elements and only emitting new ones. This may be a Set of already seen elements, an offset etc. Depends on query and data model.

For AllPersistenceIds query a AllPersistenceIdsPublisher actor would be spawned and it would have to maintain the state of the stream. On initialization it would query the database for all currently existing persistenceIds in the data store. Then it would use configured timer to query the database again, but  only publish the new persistenceIds to the stream. It should be possible to further reduce the size of the in memory state and optimize by sharing one set of already seen persistenceIds for all AllPersistenceIds queries, because the resulting events in the stream are the same for all queries (e.g. single Set[String] maintaining known persistenceIds instead of one Set[String] per query). Each query may start at different time and have a different refreshInterval, but that can be handled (i.e. merging the refreshIntervals so for each query the new persistenceIds would be emitted on specified refreshInterval or earlier, but never later). This optimization would only be possible for AllPersistenceIds query. In other cases we would have to manage the state with higher granularity. But such optimization does not change the concept.

Therefore in this implementation there is no push from database to subscribers and pulls are happening after configured intervals. The database here could be represented by CassandraJournal. I am not happy with that - I would either prefer each publisher to talk to database directly or through a read journal. But some of the queries could use some of the existing methods in CassandraJournal (CassandraRecovery). It would require some refactoring to decouple that functionality from CassandraJournal which I don’t want to immediately do without a review, but could be a way forward.

The advantage is that the implementation is very simple, does not have to manage subscriptions, push from database/write side etc. On the other hand it may be less efficient, because database may be queried even if there were no new events.

###### 2) Push - pull hybrid approach ######
If my assumption is correct and multiple CassandraJournal actors may live in a clustered system it is not possible to trivially push to read journal the way it is done in the LevelDB read journal implementation. It would only push changes in the local system which is not sufficient (for AllPersistenceIds because other nodes may accept writes and for EventsByPersistenceId even if all updates went through local journal because actors may potenatially be rebalanced). 
Instead of a pure pull approach described above we could still consider a hybrid push pull approach similar to the LevelDB implementation. CassandraJournal would then have to manage subscriptions. Then changes going through the write journal could be pushed to the subscribers (e.g. new persistenceId, new event for persistenceId x). We would have to utilize replication, e.g. using Akka Distributed Data to propagate the knowledge about updates to other nodes. 

This option would definitely be more complicated to implement. On the other hand it could help to avoid unnecessary database queries. For AllPersistenceIds for example in optimized case there would only be one query to database on CassandraJournal start and then only updates would be received using a replicated Set between the write sides.

I think I am personally in favour of 1). It looks both concept and implementation wise cleaner and simpler and it does not couple read and write sides. 