### PR TITLE
[#76] Find highest sequence nr via a single limit query per partition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,11 @@ parallelExecution in Test := false
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.5",
   "com.typesafe.akka"      %% "akka-persistence"                  % "2.4.0-RC1",
-  "com.typesafe.akka"      %% "akka-persistence-tck"              % "2.4.0-RC1"   % "test",
-  "org.scalatest"          %% "scalatest"                         % "2.1.4"   % "test",
-  "org.cassandraunit"       % "cassandra-unit"                    % "2.0.2.2" % "test"
+  "com.typesafe.akka"      %% "akka-persistence-tck"              % "2.4.0-RC1"  % "test",
+  "org.scalatest"          %% "scalatest"                         % "2.1.4"      % "test",
+  // override cassandra unit cassandra version as there is a bug with static columns in 2.1.3
+  // remove once PR https://github.com/jsevellec/cassandra-unit/pull/141 merged/released
+  "org.apache.cassandra"    % "cassandra-all"                     % "2.1.8"      % "test",
+  "org.cassandraunit"       % "cassandra-unit"                    % "2.1.3.1"    % "test"
 )
 

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -49,7 +49,7 @@ trait CassandraStatements {
 
   def selectHighestSequenceNr =
     s"""
-       SELECT sequence_nr FROM ${tableName} WHERE
+       SELECT sequence_nr, used FROM ${tableName} WHERE
        persistence_id = ? AND
        partition_nr = ?
        ORDER BY sequence_nr


### PR DESCRIPTION
After finishing this I did find the isNull on the driver Row which we could use to map the sequence nr to an Optional, might be clearer than the (tested) assumption it will be mapped to 0. Happy to update if you think that is better.