### PR TITLE
[#80] Store deleted_to in a metadata table to make deletes atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To include the Cassandra plugins into your `sbt` project, add the following line
 
     libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.4-SNAPSHOT"
 
-This version of `akka-persistence-cassandra` depends on Akka Akka 2.4-RC1 and is cross-built against Scala 2.10.4 and 2.11.6. It is compatible with Cassandra 2.1.0 or higher. Versions of the Cassandra plugins that are compatible with Cassandra 1.2.x are maintained on the [cassandra-1.2](https://github.com/krasserm/akka-persistence-cassandra/tree/cassandra-1.2) branch.
+This version of `akka-persistence-cassandra` depends on Akka Akka 2.4-RC2 and is cross-built against Scala 2.10.4 and 2.11.6. It is compatible with Cassandra 2.1.0 or higher. Versions of the Cassandra plugins that are compatible with Cassandra 1.2.x are maintained on the [cassandra-1.2](https://github.com/krasserm/akka-persistence-cassandra/tree/cassandra-1.2) branch.
    
 Migrating from 0.3 (Akka 2.3)
 -----------------------------
@@ -49,6 +49,7 @@ This will run the journal with its default settings. The default settings can be
 - `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
 - `cassandra-journal.data-center-replication-factors`. Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
 - `cassandra-journal."max-message-batch-size"`. Maximum number of messages that will be batched when using `persistAsync`. Also used as the max batch size for deletes.
+- `cassandra-journal.delete-retries`. Deletes are achieved using a metadata entry and then the actual messages are deleted asynchronously. Number of retries before giving up. Default value is 3. 
 - `cassandra-journal.target-partition-size`. Target number of messages per cassandra partition. Default value is 500000. Will only go above the target if you use persistAll and persistAllAsync **Do not change this setting after table creation** (not checked yet).
 - `cassandra-journal.max-result-size`. Maximum number of entries returned per query. Queries are executed recursively, if needed, to achieve recovery goals. Default value is 50001.
 - `cassandra-journal.write-consistency`. Write consistency level. Default value is `QUORUM`.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -18,8 +18,15 @@ cassandra-journal {
   # In case that schema creation failed you can define a number of retries before giving up.
   keyspace-autocreate-retries = 1
 
+  # Deletes are achieved using a metadata entry and then the actual messages are deleted asynchronously
+  # Number of retries before giving up
+  delete-retries = 3
+
   # Name of the table to be created/used by the journal
   table = "messages"
+
+  # Name of the table to be created/used for storing metadata
+  metadata-table = "metadata"
 
   # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
   replication-strategy = "SimpleStrategy"
@@ -79,6 +86,9 @@ cassandra-snapshot-store {
 
   # Name of the table to be created/used by the snapshot store
   table = "snapshots"
+
+  # Name of the table to be created/used for storing metadata
+  metadata-table = "metadata"
 
   # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
   replication-strategy = "SimpleStrategy"

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -15,6 +15,7 @@ class CassandraPluginConfig(config: Config) {
 
   val keyspace: String = config.getString("keyspace")
   val table: String = config.getString("table")
+  val metadataTable: String = config.getString("metadata-table")
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
   val keyspaceAutoCreateRetries: Int = config.getInt("keyspace-autocreate-retries")

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -3,6 +3,9 @@ package akka.persistence.cassandra.journal
 import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
 
+import com.datastax.driver.core.policies.{LoggingRetryPolicy, RetryPolicy}
+import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
+
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.math.min
@@ -34,6 +37,7 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
     }
   }
   session.execute(createTable)
+  session.execute(createMetatdataTable)
 
   val preparedWriteMessage = session.prepare(writeMessage)
   val preparedDeletePermanent = session.prepare(deleteMessage)
@@ -41,6 +45,8 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   val preparedCheckInUse = session.prepare(selectInUse).setConsistencyLevel(readConsistency)
   val preparedWriteInUse = session.prepare(writeInUse)
   val preparedSelectHighestSequenceNr = session.prepare(selectHighestSequenceNr).setConsistencyLevel(readConsistency)
+  val preparedSelectDeletedTo = session.prepare(selectDeletedTo).setConsistencyLevel(readConsistency)
+  val preparedInsertDeletedTo = session.prepare(insertDeletedTo).setConsistencyLevel(writeConsistency)
 
   def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     // we need to preserve the order / size of this sequence even though we don't map
@@ -89,18 +95,25 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   }
 
   def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
+    val logicalDelete = session.executeAsync(preparedInsertDeletedTo.bind(persistenceId, toSequenceNr: JLong))
+
     val fromSequenceNr = readLowestSequenceNr(persistenceId, 1L)
     val lowestPartition = partitionNr(fromSequenceNr)
     val highestPartition = partitionNr(toSequenceNr) + 1 // may have been moved to the next partition
     val partitionInfos = (lowestPartition to highestPartition).map(partitionInfo(persistenceId, _, toSequenceNr))
 
-    val asyncDeletions = partitionInfos.map( future => future.flatMap( pi => {
+    partitionInfos.map( future => future.flatMap( pi => {
       Future.sequence((pi.minSequenceNr to pi.maxSequenceNr).grouped(config.maxMessageBatchSize).map { group => {
-          asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
+          val delete = asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
+          delete.onFailure {
+            case e => log.warning(s"Unable to complete deletes for persistence id ${persistenceId}, toSequenceNr ${toSequenceNr}. The plugin will continue to function correctly but you will need to manually delete the old messages.", e)
+          }
+          delete
         }
       })
     }))
-    Future.sequence(asyncDeletions).map(_ => ())
+
+    logicalDelete.map(_ => ())
   }
 
   private def partitionInfo(persistenceId: String, partitionNr: Long, maxSequenceNr: Long): Future[PartitionInfo] = {
@@ -110,14 +123,15 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
         .getOrElse(PartitionInfo(partitionNr, minSequenceNr(partitionNr), -1)))
   }
 
-  private def asyncDeleteMessages(partitionNr: Long, messageIds: Seq[MessageId]): Future[Unit] = executeBatch { batch =>
+  private def asyncDeleteMessages(partitionNr: Long, messageIds: Seq[MessageId]): Future[Unit] = executeBatch({ batch =>
     messageIds.foreach { mid =>
       batch.add(preparedDeletePermanent.bind(mid.persistenceId, partitionNr: JLong, mid.sequenceNr: JLong))
     }
-  }
+  }, Some(config.deleteRetries))
 
-  private def executeBatch(body: BatchStatement ⇒ Unit): Future[Unit] = {
+  private def executeBatch(body: BatchStatement ⇒ Unit, retries: Option[Int] = None): Future[Unit] = {
     val batch = new BatchStatement().setConsistencyLevel(writeConsistency).asInstanceOf[BatchStatement]
+    retries.foreach(times => batch.setRetryPolicy(new LoggingRetryPolicy(new FixedRetryPolicy(times))))
     body(batch)
     session.executeAsync(batch).map(_ => ())
   }
@@ -146,4 +160,14 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   private case class SerializedAtomicWrite(persistenceId: String, payload: Seq[Serialized])
   private case class Serialized(sequenceNr: Long, serialized: ByteBuffer)
   private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)
+}
+
+class FixedRetryPolicy(number: Int) extends RetryPolicy {
+  def onUnavailable(statement: Statement, cl: ConsistencyLevel, requiredReplica: Int, aliveReplica: Int, nbRetry: Int): RetryDecision = retry(cl, nbRetry)
+  def onWriteTimeout(statement: Statement, cl: ConsistencyLevel, writeType: WriteType, requiredAcks: Int, receivedAcks: Int, nbRetry: Int): RetryDecision = retry(cl, nbRetry)
+  def onReadTimeout(statement: Statement, cl: ConsistencyLevel, requiredResponses: Int, receivedResponses: Int, dataRetrieved: Boolean, nbRetry: Int): RetryDecision = retry(cl, nbRetry)
+
+  private def retry(cl: ConsistencyLevel, nbRetry: Int): RetryDecision = {
+    if (nbRetry < number) RetryDecision.retry(cl) else RetryDecision.rethrow()
+  }
 }

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -9,4 +9,5 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
   val targetPartitionSize: Int = config.getInt("target-partition-size") // TODO: make persistent
   val gc_grace_seconds: Long = config.getLong("gc-grace-seconds")
   val maxMessageBatchSize = config.getInt("max-message-batch-size")
+  val deleteRetries: Int = config.getInt("delete-retries")
 }

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -15,6 +15,7 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
       |keyspace-autocreate-retries = 1
       |keyspace = test-keyspace
       |table = test-table
+      |metadata-table = test-metadata-table
       |replication-strategy = "SimpleStrategy"
       |replication-factor = 1
       |data-center-replication-factors = []
@@ -23,6 +24,7 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
       |contact-points = ["127.0.0.1"]
       |port = 9142
       |max-result-size = 50
+      |delete-retries = 4
     """.stripMargin)
 
 
@@ -30,6 +32,11 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
     "set the fetch size to the max result size" in {
       val config = new CassandraPluginConfig(defaultConfig)
       config.fetchSize must be(50)
+    }
+
+    "set the metadata table" in {
+      val config = new CassandraPluginConfig(defaultConfig)
+      config.metadataTable must be("test-metadata-table")
     }
 
     "parse config with host:port values as contact points" in {

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -351,7 +351,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
-      expectMsg("updated-b-6") // sequence number of permanently deleted message can be re-used
+      expectMsg("updated-b-7") // no longer re-using sequence numbers
     }
     "properly recover after all messages have been deleted" in {
       val persistenceId = UUID.randomUUID().toString
@@ -369,7 +369,7 @@ class CassandraIntegrationSpec extends TestKit(ActorSystem("test", config)) with
       val r = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
 
       r ! "b"
-      expectMsgAllOf("b", 1L, false)
+      expectMsgAllOf("b", 2L, false) // no longer re-using sequence numbers
     }
   }
 }


### PR DESCRIPTION
Used a separate table as the messages table isn't partitioned by persistence id.