### PR TITLE
Target partition size sync fix

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraConfigChecker.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraConfigChecker.scala
@@ -1,0 +1,27 @@
+package akka.persistence.cassandra.journal
+
+import scala.collection.JavaConverters._
+import com.datastax.driver.core._
+
+
+trait CassandraConfigChecker extends CassandraStatements {
+  def session: Session
+
+  def initializePersistentConfig: Map[String, String] = {
+    val result = session.execute(selectConfig).all().asScala
+      .map(row => (row.getString("property"), row.getString("value"))).toMap
+
+    result.get(CassandraJournalConfig.TargetPartitionProperty) match {
+      case Some(oldValue) => assertCorrectPartitionSize(oldValue)
+      case None =>
+        val query = session.execute(writeConfig, CassandraJournalConfig.TargetPartitionProperty, config.targetPartitionSize.toString)
+        if (!query.wasApplied()) {
+          Option(query.one).map(_.getString("value")).foreach(assertCorrectPartitionSize)
+        }
+    }
+    result + (CassandraJournalConfig.TargetPartitionProperty -> config.targetPartitionSize.toString)
+  }
+
+  private def assertCorrectPartitionSize(size: String) =
+    require(size.toInt == config.targetPartitionSize, "Can't change target-partition-size")
+}

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -62,7 +62,7 @@ trait CassandraStatements {
     """
 
   def writeConfig = s"""
-      INSERT INTO ${configTableName}(property, value) VALUES(?, ?)
+      INSERT INTO ${configTableName}(property, value) VALUES(?, ?) IF NOT EXISTS
     """
 
   def selectHighestSequenceNr = s"""

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraConfigCheckerSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraConfigCheckerSpec.scala
@@ -1,0 +1,140 @@
+package akka.persistence.cassandra.journal
+
+import java.util.concurrent.Executors
+
+import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
+import akka.persistence._
+import akka.persistence.cassandra.{CassandraLifecycle, CassandraPluginConfig}
+import akka.testkit.{ImplicitSender, TestKit}
+import com.datastax.driver.core.Session
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+object CassandraConfigCheckerSpec {
+  val config = ConfigFactory.parseString(
+    """
+      |akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
+      |akka.persistence.journal.plugin = "cassandra-journal"
+      |akka.persistence.journal.max-deletion-batch-size = 3
+      |akka.persistence.publish-confirmations = on
+      |akka.persistence.publish-plugin-commands = on
+      |akka.test.single-expect-default = 10s
+      |cassandra-journal.target-partition-size = 5
+      |cassandra-journal.max-result-size = 3
+      |cassandra-journal.port = 9142
+      |cassandra-snapshot-store.port = 9142
+    """.stripMargin)
+
+  class DummyActor(val persistenceId: String, receiver: ActorRef) extends PersistentActor {
+    def receiveRecover: Receive = {
+      case x => ()
+    }
+
+    def receiveCommand: Receive = {
+      case x: String => persist(x) { msg => receiver ! s"Received $msg" }
+    }
+  }
+}
+
+import akka.persistence.cassandra.journal.CassandraConfigCheckerSpec._
+
+
+class CassandraConfigCheckerSpec extends TestKit(ActorSystem("test", config)) with ImplicitSender with WordSpecLike with MustMatchers with CassandraLifecycle {
+
+  implicit val cfg = config.withFallback(system.settings.config).getConfig("cassandra-journal")
+  implicit val pluginConfig = new CassandraPluginConfig(cfg)
+
+  "CassandraConfigChecker" should {
+
+    "persist value in cassandra" in {
+      waitForPersistenceInitialization()
+      val underTest = createCassandraConfigChecker
+      underTest.session.execute(s"TRUNCATE ${pluginConfig.keyspace}.${pluginConfig.configTable}")
+
+
+      val persistentConfig = underTest.initializePersistentConfig
+      persistentConfig.get(CassandraJournalConfig.TargetPartitionProperty) must be(defined)
+      persistentConfig.get(CassandraJournalConfig.TargetPartitionProperty).get must be("5")
+      getTargetSize(underTest) must be("5")
+    }
+
+    "multiple persistence should keep the same value" in {
+      waitForPersistenceInitialization()
+      val underTest = createCassandraConfigChecker
+      underTest.session.execute(s"TRUNCATE ${pluginConfig.keyspace}.${pluginConfig.configTable}")
+
+      (1 to 5).foreach(i => {
+        val underTest = createCassandraConfigChecker(pluginConfig, cfg.withValue("target-partition-size", ConfigValueFactory.fromAnyRef("5")))
+        val persistentConfig = underTest.initializePersistentConfig
+        persistentConfig.get(CassandraJournalConfig.TargetPartitionProperty).get must be("5")
+        assert(persistentConfig.contains(CassandraJournalConfig.TargetPartitionProperty))
+        getTargetSize(underTest) must be("5")
+      })
+    }
+
+    "throw exception when starting with wrong value" in {
+      waitForPersistenceInitialization()
+      val underTest = createCassandraConfigChecker
+      underTest.session.execute(s"TRUNCATE ${pluginConfig.keyspace}.${pluginConfig.configTable}")
+      underTest.initializePersistentConfig
+
+      val try3Size = createCassandraConfigChecker(pluginConfig, cfg.withValue("target-partition-size", ConfigValueFactory.fromAnyRef("3")))
+      intercept[IllegalArgumentException] {
+        try3Size.initializePersistentConfig
+      }
+
+      getTargetSize(underTest) must be("5")
+    }
+
+    "concurrent calls keep consistent value" in {
+      waitForPersistenceInitialization()
+      createCassandraConfigChecker.session.execute(s"TRUNCATE ${pluginConfig.keyspace}.${pluginConfig.configTable}")
+      implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(10))
+
+
+      val resultFuture = Future.sequence((1 to 10).map(i => Future { (i, Try {
+        val underTest = createCassandraConfigChecker(pluginConfig, cfg.withValue("target-partition-size", ConfigValueFactory.fromAnyRef(i.toString)))
+        underTest.initializePersistentConfig
+      }) }))
+
+      val result = Await.result(resultFuture, 5.seconds)
+
+      val firstSize = getTargetSize(createCassandraConfigChecker)
+
+      val (success, failure) = result.partition(_._1 == firstSize.toInt)
+      success.size must be(1)
+      success.head._2.isSuccess must be(true)
+      success.head._2.get.get(CassandraJournalConfig.TargetPartitionProperty).get must be(firstSize)
+
+      failure.foreach(_._2 match {
+        case Success(_) => fail("instance should fail due to wrong target-partition-size")
+        case Failure(e) => e.isInstanceOf[IllegalArgumentException] must be(true)
+      })
+    }
+  }
+
+  def createCassandraConfigChecker(implicit pluginConfig: CassandraPluginConfig, cfg: Config): CassandraConfigChecker = {
+
+    val clusterSession = pluginConfig.clusterBuilder.build.connect()
+
+    new CassandraConfigChecker {
+      override def session: Session = clusterSession
+      override def config: CassandraJournalConfig = new CassandraJournalConfig(cfg)
+    }
+  }
+
+  def waitForPersistenceInitialization() = {
+    val actor = system.actorOf(Props(classOf[DummyActor], "p1", self))
+    actor ! "Hi"
+    expectMsg("Received Hi")
+    actor ! PoisonPill
+  }
+
+  def getTargetSize(checker: CassandraConfigChecker): String = {
+    checker.session.execute(s"${checker.selectConfig} WHERE property='${CassandraJournalConfig.TargetPartitionProperty}'").one().getString("value")
+  }
+}


### PR DESCRIPTION
First check if parameter is set in cassandra.
When it is set then it needs to be the same as in configuration to continue or throw exception.

In most cases this value will be set so we will perform only single select in cassandra.

When it is not set try to actually insert this value with "IF NOT EXISTS".
Now if we set this value we are happy and continue.
But in the same time other instance could try insert this value and this insert won't succeed.
When this insert fails it actually returns a row that failed our query.
We just need to check that value inserted just before our insert is consistent with the one we tried to insert.

First PR so let me know if I can improve anything somehow.