### PR TITLE
fix typo in test parameters target-partition-size

### DIFF
--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -22,7 +22,7 @@ object CassandraIntegrationSpec {
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
       |akka.test.single-expect-default = 10s
-      |cassandra-journal.max-partition-size = 5
+      |cassandra-journal.target-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.port = 9142
       |cassandra-snapshot-store.port = 9142

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraSslSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraSslSpec.scala
@@ -20,7 +20,7 @@ object CassandraSslSpec {
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
       |akka.test.single-expect-default = 10s
-      |cassandra-journal.max-partition-size = 5
+      |cassandra-journal.target-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.port = 9142
       |cassandra-snapshot-store.port = 9142


### PR DESCRIPTION
Someone renamed it in config but forgot in testing configuration.