### PR TITLE
Logging of slow queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,11 +26,14 @@ scalacOptions ++= Seq(
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.5",
+  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.8",
   "com.typesafe.akka"      %% "akka-persistence"                  % "2.4.0",
   "com.typesafe.akka"      %% "akka-persistence-tck"              % "2.4.0"      % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"      % "test",
-  "org.cassandraunit"       % "cassandra-unit"                    % "2.1.9.2"    % "test"
+  "org.cassandraunit"       % "cassandra-unit"                    % "2.1.9.2"    % "test",
+  "log4j"                   % "log4j"                             % "1.2.17"     % "test",
+  "org.slf4j"               % "slf4j-log4j12"                     % "1.7.5"      % "test",
+  "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.8"      % "test" classifier "tests"
 )
 
 credentials += Credentials(

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,6 +65,10 @@ cassandra-journal {
   # The time to wait before cassandra will remove the thombstones created for deleted entries.
   # cfr. gc_grace_seconds table property documentation on http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
   gc-grace-seconds = 864000
+
+  # make it true to log queries slower than `slow-query-time` (see https://github.com/datastax/java-driver/tree/2.1/features/logging)
+  log-slow-query = false
+  slow-query-time = 2s
 }
 
 cassandra-snapshot-store {
@@ -134,4 +138,8 @@ cassandra-snapshot-store {
       parallelism-max = 8
     }
   }
+
+  # make it true to log snapshot queries slower than `slow-query-time` (see https://github.com/datastax/java-driver/tree/2.1/features/logging)
+  log-slow-query = false
+  slow-query-time = 2s
 }

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -1,6 +1,7 @@
 package akka.persistence.cassandra
 
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 
 import com.datastax.driver.core.policies.{TokenAwarePolicy, DCAwareRoundRobinPolicy}
 import com.datastax.driver.core.{QueryOptions, Cluster, ConsistencyLevel, SSLOptions}
@@ -65,6 +66,9 @@ class CassandraPluginConfig(config: Config) {
 
     clusterBuilder.withSSL(new SSLOptions(context,SSLOptions.DEFAULT_SSL_CIPHER_SUITES))
   }
+
+  val logSlowQuery = config.getBoolean("log-slow-query")
+  val slowQueryTime = config.getDuration("slow-query-time", TimeUnit.MILLISECONDS)
 }
 
 object CassandraPluginConfig {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -28,6 +28,9 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
   import config._
 
   val cluster = clusterBuilder.build
+  if (logSlowQuery) {
+    cluster.register(QueryLogger.builder(cluster).withConstantThreshold(slowQueryTime).build())
+  }
   val session = cluster.connect()
 
   case class MessageId(persistenceId: String, sequenceNr: Long)

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -25,6 +25,9 @@ class CassandraSnapshotStore extends SnapshotStore with CassandraStatements with
   import config._
 
   val cluster = clusterBuilder.build
+  if (logSlowQuery) {
+    cluster.register(QueryLogger.builder(cluster).withConstantThreshold(slowQueryTime).build())
+  }
   val session = cluster.connect()
 
   if (config.keyspaceAutoCreate) {

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -29,6 +29,8 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
       |port = 9142
       |max-result-size = 50
       |delete-retries = 4
+      |log-slow-query = false
+      |slow-query-time = 2s
     """.stripMargin)
 
 


### PR DESCRIPTION
For troubleshooting, it is possible to log queries that takes more
than a certain amount of time with:

~~~
cassandra-journal.log-slow-query = true
cassandra-journal.slow-query-time = 2s
~~~

Then if one of the journal or snapshot query takes more than 2 seconds it will be
logged at the DEBUG level to the "com.datastax.driver.core.QueryLogger.SLOW"
slf4j logger.

