### PR TITLE
Don't use BATCH when a single message is persisted.

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -8,7 +8,6 @@ import akka.persistence.cassandra._
 import akka.persistence.journal.AsyncWriteJournal
 import akka.serialization.SerializationExtension
 import com.datastax.driver.core._
-import com.datastax.driver.core.exceptions.NoHostAvailableException
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
 import com.datastax.driver.core.policies.{LoggingRetryPolicy, RetryPolicy}
 import com.datastax.driver.core.utils.Bytes
@@ -63,12 +62,16 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
     })
     val result = serialized.map(a => a.map(_ => ()))
 
-    val byPersistenceId = serialized.collect({ case Success(caw) => caw }).groupBy(_.persistenceId).values
+    val byPersistenceId = serialized.collect { case Success(caw) => caw }.groupBy(_.persistenceId).values
     val boundStatements = byPersistenceId.map(statementGroup)
 
-    val batchStatements = boundStatements.map({ unit =>
-        executeBatch(batch => unit.foreach(batch.add))
-    })
+    val batchStatements = boundStatements.map { unit =>
+      unit.length match {
+        case 0 => Future.successful(())
+        case 1 => execute(unit.head)
+        case _ => executeBatch(batch => unit.foreach(batch.add))
+      }
+    }
     val promise = Promise[Seq[Try[Unit]]]()
 
     Future.sequence(batchStatements).onComplete {
@@ -140,6 +143,12 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
     retries.foreach(times => batch.setRetryPolicy(new LoggingRetryPolicy(new FixedRetryPolicy(times))))
     body(batch)
     session.executeAsync(batch).map(_ => ())
+  }
+
+  private def execute(stmt: Statement, retries: Option[Int] = None): Future[Unit] = {
+    stmt.setConsistencyLevel(writeConsistency)
+    retries.foreach(times => stmt.setRetryPolicy(new LoggingRetryPolicy(new FixedRetryPolicy(times))))
+    session.executeAsync(stmt).map(_ => ())
   }
 
   def partitionNr(sequenceNr: Long): Long =


### PR DESCRIPTION
When the app `persist`s an event most often this should result in a
single message to be written.
In our application we're persisting events with a payload > 5kb,
which triggers a warning in C* due to the default setting of
`batch_size_warn_threshold: 5k`, which will not be triggered for
`executeAsync` (if this warning is valid or not for single-partition/
single-statement batches might be clarified in the future, see also
https://issues.apache.org/jira/browse/CASSANDRA-6487).

Our ops team prefers not to increase this configuration, because in case
of C* stability issues Datastax at first points to such settings that
don't follow the recommendations.