### PR TITLE
Removed cold_reads_to_omit to be compatible with Cassandra 2.2.3

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/compaction/SizeTieredCompactionStrategy.scala
+++ b/src/main/scala/akka/persistence/cassandra/compaction/SizeTieredCompactionStrategy.scala
@@ -20,7 +20,6 @@ class SizeTieredCompactionStrategy(config: Config) extends BaseCompactionStrateg
 
   val bucketHigh: Double = if (config.hasPath("bucket_high")) config.getDouble("bucket_high") else 1.5
   val bucketLow: Double = if (config.hasPath("bucket_low")) config.getDouble("bucket_low") else 0.5
-  val coldReadsToOmit: Double = if (config.hasPath("cold_reads_to_omit")) config.getDouble("cold_reads_to_omit") else 0.05
   val maxThreshold: Int = if (config.hasPath("max_threshold")) config.getInt("max_threshold") else 32
   val minThreshold: Int = if (config.hasPath("min_threshold")) config.getInt("min_threshold") else 4
   val minSSTableSize: Long = if (config.hasPath("min_sstable_size")) config.getLong("min_sstable_size") else 50
@@ -37,7 +36,6 @@ class SizeTieredCompactionStrategy(config: Config) extends BaseCompactionStrateg
        |${super.asCQL},
        |'bucket_high' : $bucketHigh,
        |'bucket_low' : $bucketLow,
-       |'cold_reads_to_omit' : $coldReadsToOmit,
        |'max_threshold' : $maxThreshold,
        |'min_threshold' : $minThreshold,
        |'min_sstable_size' : $minSSTableSize
@@ -52,7 +50,6 @@ object SizeTieredCompactionStrategy extends CassandraCompactionStrategyConfig[Si
     BaseCompactionStrategy.propertyKeys union List(
       "bucket_high",
       "bucket_low",
-      "cold_reads_to_omit",
       "max_threshold",
       "min_threshold",
       "min_sstable_size"

--- a/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -157,7 +157,6 @@ class CassandraCompactionStrategySpec extends WordSpec with MustMatchers with Ca
           | unchecked_tombstone_compaction = false
           | bucket_high = 5.0
           | bucket_low = 2.5
-          | cold_reads_to_omit = 0.01
           | max_threshold = 20
           | min_threshold = 10
           | min_sstable_size = 100
@@ -172,7 +171,6 @@ class CassandraCompactionStrategySpec extends WordSpec with MustMatchers with Ca
       compactionStrategy.uncheckedTombstoneCompaction mustEqual false
       compactionStrategy.bucketHigh mustEqual 5.0
       compactionStrategy.bucketLow mustEqual 2.5
-      compactionStrategy.coldReadsToOmit mustEqual 0.01
       compactionStrategy.maxThreshold mustEqual 20
       compactionStrategy.minThreshold mustEqual 10
       compactionStrategy.minSSTableSize mustEqual 100
@@ -188,7 +186,6 @@ class CassandraCompactionStrategySpec extends WordSpec with MustMatchers with Ca
           | unchecked_tombstone_compaction = false
           | bucket_high = 5.0
           | bucket_low = 2.5
-          | cold_reads_to_omit = 0.01
           | max_threshold = 20
           | min_threshold = 10
           | min_sstable_size = 100


### PR DESCRIPTION
I get this error when running against Cassandra 2.2.3

`Properties specified [cold_reads_to_omit] are not understood by SizeTieredCompactionStrategy`

Removed the lines referencing cold_reads_to_omit. 

Please refer to this commit from the apache cassandra project. https://github.com/apache/cassandra/commit/33a9adac8e11cc4b01aa305868412b74048d3b34