### PR TITLE
Retry failing write requests, add `write-retries` config (forward port to cassandra-3.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This will run the journal with its default settings. The default settings can be
 - `cassandra-journal.replication-factor`. Replication factor to use when a keyspace is created by the plugin. Default value is `1`.
 - `cassandra-journal.data-center-replication-factors`. Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
 - `cassandra-journal.max-message-batch-size`. Maximum number of messages that will be batched when using `persistAsync`. Also used as the max batch size for deletes.
+- `cassandra-journal.write-retries`. The number of retries when a write request returns a TimeoutException or an UnavailableException. Default value is 3.
 - `cassandra-journal.delete-retries`. Deletes are achieved using a metadata entry and then the actual messages are deleted asynchronously. Number of retries before giving up. Default value is 3. 
 - `cassandra-journal.target-partition-size`. Target number of messages per cassandra partition. Default value is 500000. Will only go above the target if you use persistAll and persistAllAsync **Do not change this setting after table creation** (not checked yet).
 - `cassandra-journal.max-result-size`. Maximum number of entries returned per query. Queries are executed recursively, if needed, to achieve recovery goals. Default value is 50001.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -18,6 +18,9 @@ cassandra-journal {
   # In case that schema creation failed you can define a number of retries before giving up.
   keyspace-autocreate-retries = 1
 
+  # The number of retries when a write request returns a TimeoutException or an UnavailableException.
+  write-retries = 3
+
   # Deletes are achieved using a metadata entry and then the actual messages are deleted asynchronously
   # Number of retries before giving up
   delete-retries = 3

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -12,6 +12,7 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
   val gc_grace_seconds: Long = config.getLong("gc-grace-seconds")
   val maxMessageBatchSize = config.getInt("max-message-batch-size")
   val deleteRetries: Int = config.getInt("delete-retries")
+  val writeRetries: Int = config.getInt("write-retries")
   val eventsByTagView: String = config.getString("events-by-tag-view")
 
   val maxTagsPerEvent: Int = 3


### PR DESCRIPTION
This is especially useful for PersistentActors with bigger journals /
more events to replay in case of write errors. But also for smaller
journals write retries are probably what a user might expect / want,
therefore the default=3 is chosen.

Refs #87

(cherry picked from commit 1d30b105dc6d3ba27e964f89bedc13bbdecd1b2c)